### PR TITLE
Reduce StringBuilder garbage produced by Node.getTextContent

### DIFF
--- a/jodd-lagarto/src/main/java/jodd/lagarto/dom/Node.java
+++ b/jodd-lagarto/src/main/java/jodd/lagarto/dom/Node.java
@@ -893,6 +893,14 @@ public abstract class Node implements Cloneable {
 	 */
 	public String getTextContent() {
 		StringBuilder sb = new StringBuilder(getChildNodesCount() + 1);
+		appendTextContent(sb);
+		return sb.toString();
+	}
+
+	/**
+	 * Appends the text content to a StringBuilder.
+	 */
+	public void appendTextContent(StringBuilder sb) {
 		if (nodeValue != null) {
 			if ((nodeType == NodeType.TEXT) || (nodeType == NodeType.CDATA)) {
 				sb.append(nodeValue);
@@ -901,7 +909,7 @@ public abstract class Node implements Cloneable {
 		if (childNodes != null) {
 			for (int i = 0, childNodesSize = childNodes.size(); i < childNodesSize; i++) {
 				Node childNode = childNodes.get(i);
-				sb.append(childNode.getTextContent());
+				childNode.appendTextContent(sb);
 			}
 		}
 		return sb.toString();

--- a/jodd-lagarto/src/main/java/jodd/lagarto/dom/Text.java
+++ b/jodd-lagarto/src/main/java/jodd/lagarto/dom/Text.java
@@ -52,6 +52,14 @@ public class Text extends Node {
 	}
 
 	/**
+	 * Appends the text content to a StringBuilder.
+	 */
+	@Override
+	public void appendTextContent(StringBuilder sb) {
+		sb.append(getTextContent());
+	}
+
+	/**
 	 * Sets HTML text, but encodes it first.
 	 */
 	public void setTextStrict(String text) {


### PR DESCRIPTION
I make sometimes make an intensive usage of Node.getTextContent.
It's a pity that a new StringBuilder gets created for every recursive getTextContent call.
