### PR TITLE
 Add support for 0b "alternate" prefix

### DIFF
--- a/jodd-core/src/main/java/jodd/format/PrintfFormat.java
+++ b/jodd-core/src/main/java/jodd/format/PrintfFormat.java
@@ -43,8 +43,9 @@ public class PrintfFormat {
 	 *               <dt> 0 <dd> show leading zeroes
 	 *               <dt> - <dd> align left in the field
 	 *               <dt> space <dd> prepend a space in front of positive numbers
-	 *               <dt> # <dd> use "alternate" format. Add 0 or 0x for octal or hexadecimal numbers.
-	 *               Don't suppress trailing zeroes in general floating point format.
+	 *               <dt> # <dd> use "alternate" format. Add 0 or 0x for octal or hexadecimal numbers;
+	 *               add 0b for binary numbers.  Don't suppress trailing zeroes in general floating 
+	 *               point format.
 	 *               <dt> , <dd> groups decimal values by thousands (for 'diuxXb' formats)
 	 *               </dl>
 	 *
@@ -334,6 +335,21 @@ public class PrintfFormat {
 		}
 		return new String(buffer);
 	}
+	
+	private String getAltPrefixFor(char fmt, String currentPrefix) {
+		switch(fmt) {
+			case 'x':
+				return "0x";
+			case 'X':
+				return "0X";
+			case 'b':
+				return "0b";
+			case 'B':
+				return "0B";
+			default:
+				return currentPrefix;
+		}
+	}
 
 	protected String sign(int s, String r) {
 		String p = StringPool.EMPTY;
@@ -347,12 +363,12 @@ public class PrintfFormat {
 				p = StringPool.SPACE;
 			}
 		} else {
-			if (fmt == 'o' && alternate && r.length() > 0 && r.charAt(0) != '0') {
-				p = "0";
-			} else if (fmt == 'x' && alternate) {
-				p = "0x";
-			} else if (fmt == 'X' && alternate) {
-				p = "0X";
+			if (alternate) {
+				if (fmt == 'o' && r.length() > 0 && r.charAt(0) != '0') {
+					p = "0";
+				} else {
+					p = getAltPrefixFor(fmt, p);
+				}
 			}
 		}
 
@@ -502,6 +518,7 @@ public class PrintfFormat {
 				r = groupDigits(r, 4, ' ');
 				break;
 			case 'b':
+			case 'B':
 				r = Long.toBinaryString(x);
 				r = groupDigits(r, 8, ' ');
 				break;
@@ -555,6 +572,7 @@ public class PrintfFormat {
 				r = groupDigits(r, 4, ' ');
 				break;
 			case 'b':
+			case 'B':
 				r = Integer.toBinaryString(x);
 				r = groupDigits(r, 8, ' ');
 				break;
@@ -621,6 +639,7 @@ public class PrintfFormat {
 				r = groupDigits(r, 4, ' ');
 				break;
 			case 'b':
+			case 'B':
 				r = Integer.toBinaryString(value & unsignedMask);
 				r = groupDigits(r, 8, ' ');
 				break;

--- a/jodd-core/src/test/java/jodd/format/FormatTest.java
+++ b/jodd-core/src/test/java/jodd/format/FormatTest.java
@@ -10,13 +10,18 @@ public class FormatTest {
 
 	@Test
 	public void testByte() {
+		assertEquals("0b010001", Printf.str("%#08b", 0x11));
 		byte b = Byte.MAX_VALUE;
 		assertEquals("127", Printf.str("%i", b));
 		assertEquals("127", Printf.str("%u", b));
 		assertEquals("7f", Printf.str("%x", b));
 		assertEquals("7F", Printf.str("%X", b));
 		assertEquals("1111111", Printf.str("%b", b));
+		assertEquals("0b1111111", Printf.str("%#b", b));
+		assertEquals("0B1111111", Printf.str("%#B", b));
 		assertEquals("01111111", Printf.str("%08b", b));
+		assertEquals("0b01111111", Printf.str("%#010b", b));
+		assertEquals("0B01111111", Printf.str("%#010B", b));
 		assertEquals("177", Printf.str("%o", b));
 
 		b = -1;
@@ -25,7 +30,11 @@ public class FormatTest {
 		assertEquals("ff", Printf.str("%x", b));
 		assertEquals("FF", Printf.str("%X", b));
 		assertEquals("11111111", Printf.str("%b", b));
+		assertEquals("0b11111111", Printf.str("%#b", b));
+		assertEquals("0B11111111", Printf.str("%#B", b));
 		assertEquals("11111111", Printf.str("%08b", b));
+		assertEquals("0b11111111", Printf.str("%#08b", b));
+		assertEquals("0B11111111", Printf.str("%#08B", b));
 		assertEquals("377", Printf.str("%o", b));
 
 		b = Byte.MIN_VALUE;
@@ -34,7 +43,11 @@ public class FormatTest {
 		assertEquals("80", Printf.str("%x", b));
 		assertEquals("80", Printf.str("%X", b));
 		assertEquals("10000000", Printf.str("%b", b));
+		assertEquals("0b10000000", Printf.str("%#b", b));
+		assertEquals("0B10000000", Printf.str("%#B", b));
 		assertEquals("10000000", Printf.str("%08b", b));
+		assertEquals("0b10000000", Printf.str("%#08b", b));
+		assertEquals("0B10000000", Printf.str("%#08B", b));
 		assertEquals("200", Printf.str("%o", b));
 	}
 
@@ -46,6 +59,8 @@ public class FormatTest {
 		assertEquals("7fff", Printf.str("%x", s));
 		assertEquals("7FFF", Printf.str("%X", s));
 		assertEquals("111111111111111", Printf.str("%b", s));
+		assertEquals("0b111111111111111", Printf.str("%#b", s));
+		assertEquals("0B111111111111111", Printf.str("%#B", s));
 		assertEquals("77777", Printf.str("%o", s));
 
 		s = -1;
@@ -54,6 +69,8 @@ public class FormatTest {
 		assertEquals("ffff", Printf.str("%x", s));
 		assertEquals("FFFF", Printf.str("%X", s));
 		assertEquals("1111111111111111", Printf.str("%b", s));
+		assertEquals("0b1111111111111111", Printf.str("%#b", s));
+		assertEquals("0B1111111111111111", Printf.str("%#B", s));
 		assertEquals("177777", Printf.str("%o", s));
 
 		s = Short.MIN_VALUE;
@@ -62,6 +79,8 @@ public class FormatTest {
 		assertEquals("8000", Printf.str("%x", s));
 		assertEquals("8000", Printf.str("%X", s));
 		assertEquals("1000000000000000", Printf.str("%b", s));
+		assertEquals("0b1000000000000000", Printf.str("%#b", s));
+		assertEquals("0B1000000000000000", Printf.str("%#B", s));
 		assertEquals("100000", Printf.str("%o", s));
 	}
 
@@ -410,6 +429,22 @@ public class FormatTest {
 		assertEquals("11111111 11111111 11111111 11110011", Printf.str("%,b", -13));
 		assertEquals("1111111111111111111111111111111111111111111111111111111111110011", Printf.str("%b", -13L));
 		assertEquals("11111111 11111111 11111111 11111111 11111111 11111111 11111111 11110011", Printf.str("%,b", -13L));
+
+		assertEquals("0b1", Printf.str("%#b", 1));
+		assertEquals("0b11", Printf.str("%#b", 3));
+		assertEquals("0b1101", Printf.str("%#b", 13));
+		assertEquals("0b11111111111111111111111111110011", Printf.str("%#b", -13));
+		assertEquals("0b11111111 11111111 11111111 11110011", Printf.str("%,#b", -13));
+		assertEquals("0b1111111111111111111111111111111111111111111111111111111111110011", Printf.str("%#b", -13L));
+		assertEquals("0b11111111 11111111 11111111 11111111 11111111 11111111 11111111 11110011", Printf.str("%,#b", -13L));
+
+		assertEquals("0B1", Printf.str("%#B", 1));
+		assertEquals("0B11", Printf.str("%#B", 3));
+		assertEquals("0B1101", Printf.str("%#B", 13));
+		assertEquals("0B11111111111111111111111111110011", Printf.str("%#B", -13));
+		assertEquals("0B11111111 11111111 11111111 11110011", Printf.str("%,#B", -13));
+		assertEquals("0B1111111111111111111111111111111111111111111111111111111111110011", Printf.str("%#B", -13L));
+		assertEquals("0B11111111 11111111 11111111 11111111 11111111 11111111 11111111 11110011", Printf.str("%,#B", -13L));
 	}
 
 	@Test


### PR DESCRIPTION
Adding support for %#b format -- this produces strings like "0b11111111".

(The contributions are free to be licensed under the [BSD license](http://opensource.org/licenses/BSD-3-Clause).)
