### PR TITLE
HTTP 1.1 protocol is explained: "http 1.1 enabled by default Keep-Alive, If you add "Connection: close", it closes."

### DIFF
--- a/jodd-http/src/main/java/jodd/http/HttpBase.java
+++ b/jodd-http/src/main/java/jodd/http/HttpBase.java
@@ -277,8 +277,8 @@ public abstract class HttpBase<T> {
 	 */
 	public boolean connectionKeepAlive() {
 		String connection = header("Connection");
-		if (connection == null) {
-			return true;
+		if (connection == null && httpVersion().equalsIgnoreCase("HTTP/1.0")) {
+			return false;
 		}
 		return connection.equalsIgnoreCase("close");
 	}


### PR DESCRIPTION
HTTP 1.1 protocol is explained: "http 1.1 enabled by default Keep-Alive, If you add "Connection: close", it closes."
