### PR TITLE
if http client set Head is "HTTP/1.1",Server will keep connection persistent,but not set response head: "Connection: keep-alive"!

### DIFF
--- a/jodd-http/src/main/java/jodd/http/HttpBase.java
+++ b/jodd-http/src/main/java/jodd/http/HttpBase.java
@@ -286,9 +286,14 @@ public abstract class HttpBase<T> {
 	public boolean connectionKeepAlive() {
 		String connection = header(HEADER_CONNECTION);
 		if (connection == null) {
-			return false;
+		  if(httpVersion.equalsIgnoreCase(HTTP_1_0)) {
+		    return false;
+		  } else {
+			  return true;
+		  }
 		}
-		return connection.equalsIgnoreCase(HEADER_KEEP_ALIVE);
+
+		return !connection.equalsIgnoreCase(HEADER_CLOSE);
 	}
 
 	/**


### PR DESCRIPTION
if http client set Head is "HTTP/1.1",Server will keep connection persistent,but not set response head: "Connection: keep-alive"!
