### PR TITLE
Fixed comparing major version number in conditional comments matcher

### DIFF
--- a/jodd-lagarto/src/main/java/jodd/lagarto/dom/HtmlCCommentExpressionMatcher.java
+++ b/jodd-lagarto/src/main/java/jodd/lagarto/dom/HtmlCCommentExpressionMatcher.java
@@ -34,7 +34,7 @@ public class HtmlCCommentExpressionMatcher {
 					String value = orChunk.substring(3);
 					float number = Float.parseFloat(value);
 
-					if (ieVersion == number) {
+					if (matchMajorNumber(ieVersion, number) || ieVersion == number) {
 						innerValid = true;
 						break;
 					}
@@ -98,4 +98,13 @@ public class HtmlCCommentExpressionMatcher {
 		return valid;
 	}
 
+	private boolean matchMajorNumber(float ieVersion, float number) {
+		int majorVersion = (int) number;
+
+		// comparing only major numbers
+		if (majorVersion == number) {
+			return (int)ieVersion == majorVersion;
+		}
+		return false;
+	}
 }

--- a/jodd-lagarto/src/test/java/jodd/lagarto/dom/HtmlCCommentExpressionMatcherTest.java
+++ b/jodd-lagarto/src/test/java/jodd/lagarto/dom/HtmlCCommentExpressionMatcherTest.java
@@ -36,6 +36,10 @@ public class HtmlCCommentExpressionMatcherTest {
 		assertTrue(m.match(7, "if gte IE 6.0"));
 
 		assertFalse(m.match(5.5f, "if gte IE 6"));
+
+		assertTrue(m.match(5.4f, "if IE 5"));
+		assertTrue(m.match(5.6f, "if IE 5"));
+		assertFalse(m.match(5.5f, "if IE 5.6"));
 	}
 
 	@Test
@@ -51,5 +55,6 @@ public class HtmlCCommentExpressionMatcherTest {
 		assertFalse(m.match(7, "if (lt IE 6)|(lt IE 7)"));
 		assertTrue(m.match(7, "if (lt IE 6)|(lte IE 7)"));
 
+		assertTrue(m.match(6.5f, "if (IE 6)|(IE 7)"));
 	}
 }


### PR DESCRIPTION
Fixed matching expression like: `if IE 5`. According to [MSDN](http://msdn.microsoft.com/en-us/library/ms537512%28v=vs.85%29.aspx#Version_Vectors):

> In the following example, only the major version number is specified; therefore, the sample evaluates as true for both Internet Explorer 5 and Internet Explorer 5.5. 
