### PR TITLE
Fixed comparing version number in conditional comments for the rest of the operators

### DIFF
--- a/jodd-lagarto/src/main/java/jodd/lagarto/dom/HtmlCCommentExpressionMatcher.java
+++ b/jodd-lagarto/src/main/java/jodd/lagarto/dom/HtmlCCommentExpressionMatcher.java
@@ -34,7 +34,7 @@ public class HtmlCCommentExpressionMatcher {
 					String value = orChunk.substring(3);
 					float number = Float.parseFloat(value);
 
-					if (matchMajorNumber(ieVersion, number) || ieVersion == number) {
+					if (versionToCompare(ieVersion, number) == number) {
 						innerValid = true;
 						break;
 					}
@@ -44,7 +44,7 @@ public class HtmlCCommentExpressionMatcher {
 					String value = orChunk.substring(4);
 					float number = Float.parseFloat(value);
 
-					if (ieVersion != number) {
+					if (versionToCompare(ieVersion, number) != number) {
 						innerValid = true;
 						break;
 					}
@@ -64,7 +64,7 @@ public class HtmlCCommentExpressionMatcher {
 					String value = orChunk.substring(7);
 					float number = Float.parseFloat(value);
 
-					if (ieVersion <= number) {
+					if (versionToCompare(ieVersion, number) <= number) {
 						innerValid = true;
 						break;
 					}
@@ -74,7 +74,7 @@ public class HtmlCCommentExpressionMatcher {
 					String value = orChunk.substring(6);
 					float number = Float.parseFloat(value);
 
-					if (ieVersion > number) {
+					if (versionToCompare(ieVersion, number) > number) {
 						innerValid = true;
 						break;
 					}
@@ -98,13 +98,9 @@ public class HtmlCCommentExpressionMatcher {
 		return valid;
 	}
 
-	private boolean matchMajorNumber(float ieVersion, float number) {
-		int majorVersion = (int) number;
-
-		// comparing only major numbers
-		if (majorVersion == number) {
-			return (int)ieVersion == majorVersion;
-		}
-		return false;
+	// If in expression IE version is represented as a natural number
+	// we should compare only major number
+	private float versionToCompare(float ieVersion, float number) {
+		return (int) number == number ? (int) ieVersion : ieVersion;
 	}
 }

--- a/jodd-lagarto/src/test/java/jodd/lagarto/dom/HtmlCCommentExpressionMatcherTest.java
+++ b/jodd-lagarto/src/test/java/jodd/lagarto/dom/HtmlCCommentExpressionMatcherTest.java
@@ -40,6 +40,26 @@ public class HtmlCCommentExpressionMatcherTest {
 		assertTrue(m.match(5.4f, "if IE 5"));
 		assertTrue(m.match(5.6f, "if IE 5"));
 		assertFalse(m.match(5.5f, "if IE 5.6"));
+
+		assertFalse(m.match(9.1f, "if !IE 9"));
+		assertFalse(m.match(9.1f, "if !IE 9.0"));
+		assertTrue(m.match(9.1f, "if !IE 9.2"));
+
+		assertFalse(m.match(9.1f, "if gt IE 9"));
+		assertFalse(m.match(9.1f, "if gt IE 9.0"));
+		assertTrue(m.match(9.1f, "if gt IE 9.01"));
+
+		assertFalse(m.match(9.1f, "if lt IE 9"));
+		assertFalse(m.match(9.1f, "if lt IE 9.0"));
+		assertTrue(m.match(9.1f, "if lt IE 9.2"));
+
+		assertTrue(m.match(9.1f, "if gte IE 9"));
+		assertTrue(m.match(9.1f, "if gte IE 9.0"));
+		assertFalse(m.match(9.1f, "if gte IE 9.2"));
+
+		assertTrue(m.match(9.1f, "if lte IE 9"));
+		assertTrue(m.match(9.1f, "if lte IE 9.0"));
+		assertFalse(m.match(9.1f, "if lte IE 9.01"));
 	}
 
 	@Test


### PR DESCRIPTION
I checked how conditional comments work in real IE browser and added fixes for other operators.
