### PR TITLE
LagartoDOMBuilder double-decodes attribute values

### DIFF
--- a/jodd-lagarto/src/main/java/jodd/lagarto/dom/Node.java
+++ b/jodd-lagarto/src/main/java/jodd/lagarto/dom/Node.java
@@ -447,7 +447,7 @@ public abstract class Node implements Cloneable {
 				return;
 			}
 		}
-		attributes.add(new Attribute(rawAttributeName, name, value, true));
+		attributes.add(new Attribute(rawAttributeName, name, value, false));
 	}
 
 	/**

--- a/jodd-lagarto/src/test/java/jodd/lagarto/dom/DomBuilderTest.java
+++ b/jodd-lagarto/src/test/java/jodd/lagarto/dom/DomBuilderTest.java
@@ -292,4 +292,11 @@ public class DomBuilderTest {
 		assertEquals(textContent, charBuffer.toString());
 	}
 
+    @Test
+    public void testDoubleDecode() {
+        LagartoDOMBuilder lagartoDOMBuilder = new LagartoDOMBuilder();
+        Document document = lagartoDOMBuilder.parse("<div title=\"&amp;lt;root /&amp;gt;\">");
+        Element div = (Element) document.getFirstChild();
+        assertEquals("&lt;root /&gt;", div.getAttribute("title"));
+    }
 }


### PR DESCRIPTION
If an XML attribute contains &-encoded data (which is therefore double-encoded for storage in an attribute), it is double-decoded - once in `LagartoParser`, and again in the constructor for `Attribute` - when it is parsed by `LagartoDOMBuilder`. I've modified the `setAttribute` method of `Node` so it doesn't decode attributes any further, as this seemed like the cleanest solution.
