### PR TITLE
Allow user to set the mail subject encoding if it differs from the platform.

### DIFF
--- a/jodd-mail/src/main/java/jodd/mail/CommonEmail.java
+++ b/jodd-mail/src/main/java/jodd/mail/CommonEmail.java
@@ -156,6 +156,7 @@ public abstract class CommonEmail {
 	// ---------------------------------------------------------------- subject
 
 	protected String subject;
+	protected String subjectEncoding;
 
 	/**
 	 * Sets message subject.
@@ -163,11 +164,26 @@ public abstract class CommonEmail {
 	public void setSubject(String subject) {
 		this.subject = subject;
 	}
+
+	/**
+	 * Sets message subject with specified encoding to override default platform encoding. Also see {@link javax.mail.internet.MimeMessage#setSubject(String, String)}
+	 */
+	public void setSubject(String subject, String encoding) {
+		this.subject = subject;
+		this.subjectEncoding = encoding;
+	}
 	/**
 	 * Returns message subject.
 	 */
 	public String getSubject() {
 		return this.subject;
+	}
+
+	/**
+	 * Returns the message subject encoding.
+	 */
+	public String getSubjectEncoding() {
+		return this.subjectEncoding;
 	}
 
 	// ---------------------------------------------------------------- message

--- a/jodd-mail/src/main/java/jodd/mail/Email.java
+++ b/jodd-mail/src/main/java/jodd/mail/Email.java
@@ -280,6 +280,11 @@ public class Email extends CommonEmail {
 		return this;
 	}
 
+	public Email subject(String subject, String subjectEncoding) {
+		setSubject(subject, subjectEncoding);
+		return this;
+	}
+
 	// ---------------------------------------------------------------- message
 
 	public Email message(String text, String mimeType, String encoding) {

--- a/jodd-mail/src/main/java/jodd/mail/SendMailSession.java
+++ b/jodd-mail/src/main/java/jodd/mail/SendMailSession.java
@@ -91,7 +91,7 @@ public class SendMailSession {
 	 * Creates new JavaX message from {@link Email email}.
 	 */
 	protected Message createMessage(Email email, Session session) throws MessagingException {
-		Message msg = new MimeMessage(session);
+		MimeMessage msg = new MimeMessage(session);
 
 		msg.setFrom(email.getFrom().toInternetAddress());
 
@@ -134,7 +134,14 @@ public class SendMailSession {
 		}
 
 		// subject & date
-		msg.setSubject(email.getSubject());
+
+		if(email.getSubjectEncoding() != null) {
+			msg.setSubject(email.getSubject(), email.getSubjectEncoding());
+		} else {
+			msg.setSubject(email.getSubject());
+		}
+
+
 		Date date = email.getSentDate();
 		if (date == null) {
 			date = new Date();


### PR DESCRIPTION
Hello.

We've experienced an issue when deploy target doesn't have the default encoding set to UTF-8, but ANSI and our mail subject lines contain non-ANSI characters. 

This PRs adds a second method of setting the mail subject in `jodd.mail.Email` which takes a string specifying the encoding. If subject encoding is specified the subject is added to `javax.mail.internet.MimeMessage` with the specified encoding. If encoding is not specified it follows the normal behaviour (from MimeMessage setSubject): 

> Set the "Subject" header field. If the subject contains non US-ASCII characters, it will be encoded using the platform's default charset. If the subject contains only US-ASCII characters, no encoding is done and it is used as-is. If the subject is null, the existing "Subject" field is removed.

Tested to work as intended in our environment.
