### PR TITLE
Fixing isHostUnix() false positive value on Mac OS X

### DIFF
--- a/jodd-core/src/main/java/jodd/util/SystemUtil.java
+++ b/jodd-core/src/main/java/jodd/util/SystemUtil.java
@@ -310,7 +310,9 @@ public class SystemUtil {
 	 * Returns <code>true</code> if host is a general unix.
 	 */
 	public static boolean isHostUnix() {
-		return File.pathSeparator.equals(StringPool.COLON);
+		boolean unixVariant = isHostAix() | isHostLinux() | isHostMac() | isHostSolaris();
+
+		return (!unixVariant && File.pathSeparator.equals(StringPool.COLON));
 	}
 
 	/**


### PR DESCRIPTION
Hi Igor,

As mentioned in https://github.com/oblac/jodd/issues/193 I ran into this during testing my application on Mac OS X.

I red about a bit, and I'm not sure, whether you intend to use isHostUnix, to return true any other Unix versions that are already handled by isHostAIX(), isHostLinux(), etc. or return true for any of the variants of Unix?

org.apache.commons.lang.SystemUtils uses the latter version.

My  fix follows the former version.