### PR TITLE
fix: when socket is closed by remote serever!

### DIFF
--- a/jodd-http/src/main/java/jodd/http/HttpRequest.java
+++ b/jodd-http/src/main/java/jodd/http/HttpRequest.java
@@ -702,7 +702,17 @@ public class HttpRequest extends HttpBase<HttpRequest> {
 		// prepare http connection
 
 		if (timeout != -1) {
-			httpConnection.setTimeout(timeout);
+		  try {
+			  httpConnection.setTimeout(timeout);
+		  } catch(Throwable thex) {  //@wjw_add
+		    try {
+	        httpConnection.close();
+		    } catch(Throwable thex2) {
+		    } finally {
+	        httpConnection = null;
+		    }
+		    throw thex;
+		  }
 		}
 
 		// sends data


### PR DESCRIPTION
fix: when socket is closed by remote serever,'httpConnection.setTimeout(timeout);' will throw'SocketTimeoutException'! and if is KeepAlive,Subsequent requests will always error!