### PR TITLE
Add null-check to handle attributes with no value

### DIFF
--- a/jodd-lagarto/src/main/java/jodd/csselly/selector/AttributeSelector.java
+++ b/jodd-lagarto/src/main/java/jodd/csselly/selector/AttributeSelector.java
@@ -127,6 +127,11 @@ public class AttributeSelector extends Selector implements NodeFilter {
 		}
 
 		String nodeValue = node.getAttribute(name);
+
+		if(nodeValue == null) {
+			return false;
+		}
+		
 		return match.compare(nodeValue, value);
 	}
 }

--- a/jodd-lagarto/src/test/java/jodd/jerry/JerryMiscTest.java
+++ b/jodd-lagarto/src/test/java/jodd/jerry/JerryMiscTest.java
@@ -306,4 +306,17 @@ public class JerryMiscTest {
 		assertEquals("value", div.getChild(1).getNodeValue());
 	}
 
+	@Test
+	public void testEmptyClassAttribute() {
+		Jerry doc = Jerry.jerry("<div class></div>");
+		Exception ex = null;
+		try {
+			doc.find(".foo");
+		} catch(Exception e) {
+			ex = e;
+		}
+		assertEquals(null, ex);
+	}
+
+
 }


### PR DESCRIPTION
Trying to find anything by class will fail in a document containing something like 

    <div class></div>.

I am in doubt wether the test in the right project. This is csselly change, but I could not figure out how to do a test that did not involve jerry. I am happy to change this, given any pointers.