### PR TITLE
Unit tests for jodd-decora module to increase code coverage from 63% to 90%

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -304,7 +304,7 @@ configure(javaModules()) {
 
 			systemProperties = System.properties
 
-			List<String> excludes = ['*Test*', '*.?', '*Foo*', '*.data.*', '*.tst*', 'jodd.asm5.*', 'jodd.json.mo*']
+			List<String> excludes = ['*Test*', '*.?', '*Foo*', '*.data.*', '*.tst*', 'jodd.asm5.*', 'jodd.json.mo*', 'jodd.json.db*']
 
 			jvmArgs "-javaagent:${configurations.jacoco.asPath}=destfile=${project.buildDir.path}/jacoco/${testTask.name}.exec," +
 					"sessionid=HSServ,append=false,excludes=${excludes.join(':')}",

--- a/jodd-decora/build.gradle
+++ b/jodd-decora/build.gradle
@@ -9,4 +9,6 @@ dependencies {
 	provided lib.servlet
 
 	testCompile lib.junit
+	testCompile 'org.powermock:powermock-module-junit4:1.6.3'
+	testCompile 'org.powermock:powermock-api-mockito:1.6.3'
 }

--- a/jodd-decora/src/test/java/jodd/decora/DecoraExceptionTest.java
+++ b/jodd-decora/src/test/java/jodd/decora/DecoraExceptionTest.java
@@ -1,0 +1,75 @@
+// Copyright (c) 2003-present, Jodd Team (http://jodd.org)
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice,
+// this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+package jodd.decora;
+
+import static org.junit.Assert.assertEquals;
+import static org.powermock.api.mockito.PowerMockito.mock;
+import static org.powermock.reflect.Whitebox.getInternalState;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import jodd.decora.DecoraException;
+
+public class DecoraExceptionTest {
+
+	private Throwable throwableMock;
+	private final String TEST_STRING = "TEST";
+
+	@Before
+	public void setUp() {
+		throwableMock = mock(Throwable.class);
+	}
+
+	@Test
+	public final void testDecoraExceptionThrowable() {
+		// when
+		DecoraException decoraException = new DecoraException(throwableMock);
+
+		// then
+		assertEquals("Cause field must be set.", throwableMock, getInternalState(decoraException, "cause"));
+	}
+
+	@Test
+	public final void testDecoraExceptionString() {
+		// when
+		DecoraException decoraException = new DecoraException(TEST_STRING);
+
+		// then
+		assertEquals("DetailMessage field must be set.", TEST_STRING, getInternalState(decoraException, "detailMessage"));
+	}
+
+	@Test
+	public final void testDecoraExceptionStringThrowable() {
+		// when
+		DecoraException decoraException = new DecoraException(TEST_STRING, throwableMock);
+
+		// then
+		assertEquals("Cause field must be set.", throwableMock, getInternalState(decoraException, "cause"));
+		assertEquals("DetailMessage field must be set.", TEST_STRING, getInternalState(decoraException, "detailMessage"));
+	}
+
+}

--- a/jodd-decora/src/test/java/jodd/decora/DecoraManagerTest.java
+++ b/jodd-decora/src/test/java/jodd/decora/DecoraManagerTest.java
@@ -1,0 +1,151 @@
+// Copyright (c) 2003-present, Jodd Team (http://jodd.org)
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice,
+// this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+package jodd.decora;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.powermock.api.mockito.PowerMockito.mock;
+import static org.powermock.reflect.Whitebox.getInternalState;
+import static org.powermock.reflect.Whitebox.setInternalState;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.junit.Before;
+import org.junit.Test;
+
+public class DecoraManagerTest {
+
+	private DecoraManager decoraManager;
+
+	@Before
+	public void setUp() {
+		decoraManager = new DecoraManager();
+	}
+
+	@Test
+	public final void testIsDecorateErrorPages() {
+		// when
+		setInternalState(decoraManager, "decorateErrorPages", true);
+
+		// then
+		assertTrue("DecorateErrorPages should be true.", decoraManager.isDecorateErrorPages());
+	}
+
+	@Test
+	public final void testSetDecorateErrorPages() {
+		// when
+		decoraManager.setDecorateErrorPages(true);
+
+		// then
+		assertTrue("DecorateErrorPages should be true.", (boolean) getInternalState(decoraManager, "decorateErrorPages"));
+	}
+
+	@Test
+	public final void testDecorateRequest() {
+		// when
+		HttpServletRequest httpServletRequestMock = mock(HttpServletRequest.class);
+
+		// then
+		assertTrue("DecorateRequest function always returns true.", decoraManager.decorateRequest(httpServletRequestMock));
+	}
+
+	@Test
+	public final void testDecorateContentType() {
+		// when
+		String testString = "TEST";
+
+		// then
+		assertTrue("DecorateContentType function always returns true.", decoraManager.decorateContentType(testString, testString, testString));
+	}
+
+	@Test
+	public final void testDecorateStatusCode() {
+		// when
+		int statusCode = 200;
+
+		// then
+		assertTrue("Returns <code>true</code> for status code 200", decoraManager.decorateStatusCode(statusCode));
+	}
+
+	@Test
+	public final void testDecorateStatusCode2() {
+		// when
+		int statusCode = 300;
+		setInternalState(decoraManager, "decorateErrorPages", true);
+
+		// then
+		assertFalse("Returns <code>false</code> for status code 300", decoraManager.decorateStatusCode(statusCode));
+	}
+
+	@Test
+	public final void testDecorateStatusCode3() {
+		// when
+		int statusCode = 404;
+		setInternalState(decoraManager, "decorateErrorPages", false);
+
+		// then
+		assertFalse("Returns <code>false</code> for status code 404", decoraManager.decorateStatusCode(statusCode));
+	}
+
+	@Test
+	public final void testDecorateStatusCode4() {
+		// when
+		int statusCode = 404;
+		setInternalState(decoraManager, "decorateErrorPages", true);
+
+		// then
+		assertTrue("For error pages (status code {@literal >=} 400) should return true", decoraManager.decorateStatusCode(statusCode));
+	}
+
+	@Test
+	public final void testResolveDecoratorNull() {
+		// setup
+		HttpServletRequest httpServletRequestMock = mock(HttpServletRequest.class);
+		String actionPath = "TEST";
+
+		// when
+		String result = decoraManager.resolveDecorator(httpServletRequestMock, actionPath);
+
+		// then
+		assertNull("If decorator is not found, returns <code>null</code>.", result);
+	}
+
+	@Test
+	public final void testResolveDecoratorNotNull() {
+		// setup
+		HttpServletRequest httpServletRequestMock = mock(HttpServletRequest.class);
+		String actionPath = "TEST.html";
+
+		// when
+		String result = decoraManager.resolveDecorator(httpServletRequestMock, actionPath);
+
+		// then
+		assertEquals("Result value must be equal to default decorator path.", DecoraManager.DEFAULT_DECORATOR, result);
+	}
+
+}

--- a/jodd-decora/src/test/java/jodd/decora/DecoraRequestWrapperTest.java
+++ b/jodd-decora/src/test/java/jodd/decora/DecoraRequestWrapperTest.java
@@ -1,0 +1,115 @@
+// Copyright (c) 2003-present, Jodd Team (http://jodd.org)
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice,
+// this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+package jodd.decora;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.verify;
+import static org.powermock.api.mockito.PowerMockito.mock;
+import static org.powermock.reflect.Whitebox.getInternalState;
+import static org.powermock.reflect.Whitebox.setInternalState;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.junit.Before;
+import org.junit.Test;
+
+public class DecoraRequestWrapperTest {
+
+	private HttpServletRequest httpServletRequestMock;
+	private HttpServletRequest httpServletRequestMock2;
+	private final String TEST_STRING = "TEST";
+
+	@Before
+	public void setUp() {
+		httpServletRequestMock = mock(HttpServletRequest.class);
+		httpServletRequestMock2 = mock(HttpServletRequest.class);
+	}
+
+	@Test
+	public final void testConstructor() {
+		// when
+		DecoraRequestWrapper decoraRequestWrapper = new DecoraRequestWrapper(httpServletRequestMock);
+
+		// then
+		assertEquals("Parameter should be set.", httpServletRequestMock, getInternalState(decoraRequestWrapper, "request"));
+	}
+
+	@Test
+	public final void testGetHeaderString() {
+		// setup
+		DecoraRequestWrapper decoraRequestWrapper = new DecoraRequestWrapper(httpServletRequestMock);
+		setInternalState(decoraRequestWrapper, "request", httpServletRequestMock2);
+
+		// when
+		decoraRequestWrapper.getHeader(TEST_STRING);
+
+		// then
+		verify(httpServletRequestMock2).getHeader(TEST_STRING);
+	}
+
+	@Test
+	public final void testGetHeaderStringReturnNull() {
+		// setup
+		DecoraRequestWrapper decoraRequestWrapper = new DecoraRequestWrapper(httpServletRequestMock);
+		setInternalState(decoraRequestWrapper, "request", httpServletRequestMock2);
+		String nullRespondingString = "If-Modified-Since";
+
+		// when
+		String result = decoraRequestWrapper.getHeader(nullRespondingString);
+
+		// then
+		assertNull("<code>null</code> for excluded HTTP headers.", result);
+	}
+
+	@Test
+	public final void testGetDateHeaderString() {
+		// setup
+		DecoraRequestWrapper decoraRequestWrapper = new DecoraRequestWrapper(httpServletRequestMock);
+		setInternalState(decoraRequestWrapper, "request", httpServletRequestMock2);
+
+		// when
+		decoraRequestWrapper.getDateHeader(TEST_STRING);
+
+		// then
+		verify(httpServletRequestMock2).getDateHeader(TEST_STRING);
+	}
+
+	@Test
+	public final void testGetDateHeaderStringReturnMinusOne() {
+		// setup
+		DecoraRequestWrapper decoraRequestWrapper = new DecoraRequestWrapper(httpServletRequestMock);
+		setInternalState(decoraRequestWrapper, "request", httpServletRequestMock2);
+		String nullRespondingString = "If-Modified-Since";
+
+		// when
+		long result = decoraRequestWrapper.getDateHeader(nullRespondingString);
+
+		// then
+		assertEquals("<code>-1</code> for excluded HTTP headers.", -1, result);
+	}
+
+}

--- a/jodd-decora/src/test/java/jodd/decora/DecoraResponseWrapperTest.java
+++ b/jodd-decora/src/test/java/jodd/decora/DecoraResponseWrapperTest.java
@@ -1,0 +1,175 @@
+// Copyright (c) 2003-present, Jodd Team (http://jodd.org)
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice,
+// this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+package jodd.decora;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.powermock.api.mockito.PowerMockito.mock;
+import static org.powermock.api.mockito.PowerMockito.when;
+import static org.powermock.reflect.Whitebox.getInternalState;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import jodd.servlet.wrapper.LastModifiedData;
+
+public class DecoraResponseWrapperTest {
+
+	private DecoraResponseWrapper decoraResponseWrapper;
+	private HttpServletRequest originalRequest;
+	private HttpServletResponse originalResponse;
+	private LastModifiedData lastModifiedData;
+	private DecoraManager decoraManager;
+
+	@Before
+	public void setUp() {
+		originalRequest = mock(HttpServletRequest.class);
+		originalResponse = mock(HttpServletResponse.class);
+		lastModifiedData = mock(LastModifiedData.class);
+		decoraManager = mock(DecoraManager.class);
+	}
+
+	@Test
+	public final void testConstructor() {
+		// when
+		decoraResponseWrapper = new DecoraResponseWrapper(originalRequest, originalResponse, lastModifiedData, decoraManager);
+
+		// then
+		assertEquals("Parameter should be set.", originalRequest, getInternalState(decoraResponseWrapper, "request"));
+		assertEquals("Parameter should be set.", originalResponse, getInternalState(decoraResponseWrapper, "response"));
+		assertEquals("Parameter should be set.", lastModifiedData, getInternalState(decoraResponseWrapper, "lastModifiedData"));
+		assertEquals("Parameter should be set.", decoraManager, getInternalState(decoraResponseWrapper, "decoraManager"));
+	}
+
+	@Test
+	public final void testPreResponseCommit() {
+		// setup
+		decoraResponseWrapper = new DecoraResponseWrapper(originalRequest, originalResponse, lastModifiedData, decoraManager);
+		when(lastModifiedData.getLastModified()).thenReturn(Long.valueOf(1));
+		when(originalResponse.containsHeader("Last-Modified")).thenReturn(true);
+
+		// when
+		decoraResponseWrapper.preResponseCommit();
+
+		// then
+		verify(originalResponse, never()).setDateHeader("Last-Modified", 1);
+		verify(originalResponse, never()).reset();
+		verify(originalResponse).containsHeader("Last-Modified");
+	}
+
+	@Test
+	public final void testPreResponseCommit2() {
+		// setup
+		decoraResponseWrapper = new DecoraResponseWrapper(originalRequest, originalResponse, lastModifiedData, decoraManager);
+		when(lastModifiedData.getLastModified()).thenReturn(Long.valueOf(-1));
+		when(originalResponse.containsHeader("Last-Modified")).thenReturn(true);
+
+		// when
+		decoraResponseWrapper.preResponseCommit();
+
+		// then
+		verify(originalResponse, never()).setDateHeader("Last-Modified", 1);
+		verify(originalResponse, never()).reset();
+		verify(lastModifiedData).getLastModified();
+	}
+
+	@Test
+	public final void testPreResponseCommit3() {
+		// setup
+		decoraResponseWrapper = new DecoraResponseWrapper(originalRequest, originalResponse, lastModifiedData, decoraManager);
+		when(lastModifiedData.getLastModified()).thenReturn(Long.valueOf(-1));
+		when(originalResponse.containsHeader("Last-Modified")).thenReturn(false);
+
+		// when
+		decoraResponseWrapper.preResponseCommit();
+
+		// then
+		verify(originalResponse, never()).setDateHeader("Last-Modified", 1);
+		verify(originalResponse, never()).reset();
+		verify(lastModifiedData).getLastModified();
+	}
+
+	@Test
+	public final void testPreResponseCommit4() {
+		// setup
+		decoraResponseWrapper = new DecoraResponseWrapper(originalRequest, originalResponse, lastModifiedData, decoraManager);
+		when(lastModifiedData.getLastModified()).thenReturn(Long.valueOf(1));
+		when(originalResponse.containsHeader("Last-Modified")).thenReturn(false);
+		when(originalRequest.getDateHeader("If-Modified-Since")).thenReturn(Long.MIN_VALUE);
+
+		// when
+		decoraResponseWrapper.preResponseCommit();
+
+		// then
+		verify(originalResponse).setDateHeader("Last-Modified", lastModifiedData.getLastModified());
+	}
+
+	@Test
+	public final void testPreResponseCommit5() {
+		// setup
+		decoraResponseWrapper = new DecoraResponseWrapper(originalRequest, originalResponse, lastModifiedData, decoraManager);
+		when(lastModifiedData.getLastModified()).thenReturn(Long.valueOf(1));
+		when(originalResponse.containsHeader("Last-Modified")).thenReturn(false);
+		when(originalRequest.getDateHeader("If-Modified-Since")).thenReturn(Long.MAX_VALUE);
+
+		// when
+		decoraResponseWrapper.preResponseCommit();
+
+		// then
+		verify(originalResponse).reset();
+	}
+
+	@Test
+	public final void testBufferContentType() {
+		// setup
+		decoraResponseWrapper = new DecoraResponseWrapper(originalRequest, originalResponse, lastModifiedData, decoraManager);
+		String testString = "TEST";
+
+		// when
+		decoraResponseWrapper.bufferContentType(testString, testString, testString);
+
+		// then
+		verify(decoraManager).decorateContentType(testString, testString, testString);
+	}
+
+	@Test
+	public final void testBufferStatusCode() {
+		// setup
+		decoraResponseWrapper = new DecoraResponseWrapper(originalRequest, originalResponse, lastModifiedData, decoraManager);
+		int statusCode = 1;
+
+		// when
+		decoraResponseWrapper.bufferStatusCode(statusCode);
+
+		// then
+		verify(decoraManager).decorateStatusCode(statusCode);
+	}
+
+}

--- a/jodd-decora/src/test/java/jodd/decora/DecoraServletFilterDoFilterTest.java
+++ b/jodd-decora/src/test/java/jodd/decora/DecoraServletFilterDoFilterTest.java
@@ -1,0 +1,188 @@
+// Copyright (c) 2003-present, Jodd Team (http://jodd.org)
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice,
+// this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+package jodd.decora;
+
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.powermock.api.mockito.PowerMockito.mock;
+import static org.powermock.api.mockito.PowerMockito.when;
+import static org.powermock.api.mockito.PowerMockito.whenNew;
+import static org.powermock.reflect.Whitebox.setInternalState;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.ServletOutputStream;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import jodd.decora.parser.DecoraParser;
+import jodd.util.ClassLoaderUtil;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({ ClassLoaderUtil.class, DecoraResponseWrapper.class, DecoraServletFilter.class })
+public class DecoraServletFilterDoFilterTest {
+
+	private DecoraServletFilter decoraServletFilter;
+	private HttpServletRequest httpServletRequestMock;
+	private HttpServletResponse httpServletResponseMock;
+	private FilterChain filterChainMock;
+	private DecoraManager decoraManagerMock;
+	private DecoraResponseWrapper decoraResponseWrapperMock;
+	private DecoraParser decoraParserMock;
+	private PrintWriter printWriterMock;
+
+	@Before
+	public void setUp() throws Exception {
+		decoraServletFilter = new DecoraServletFilter();
+		httpServletRequestMock = mock(HttpServletRequest.class);
+		httpServletResponseMock = mock(HttpServletResponse.class);
+		filterChainMock = mock(FilterChain.class);
+		decoraManagerMock = mock(DecoraManager.class);
+		decoraParserMock = mock(DecoraParser.class);
+		decoraResponseWrapperMock = mock(DecoraResponseWrapper.class);
+		printWriterMock = mock(PrintWriter.class);
+		setInternalState(decoraServletFilter, "decoraParser", decoraParserMock);
+		setInternalState(decoraServletFilter, "decoraManager", decoraManagerMock);
+		when(httpServletResponseMock.getWriter()).thenReturn(printWriterMock);
+		when(httpServletResponseMock.getOutputStream()).thenReturn(mock(ServletOutputStream.class));
+		when(decoraResponseWrapperMock.isBufferStreamBased()).thenReturn(true);
+		whenNew(DecoraResponseWrapper.class).withAnyArguments().thenReturn(decoraResponseWrapperMock);
+	}
+
+	@Test
+	public final void testDoFilterDecorateRequestFalse() throws IOException, ServletException {
+		// setup
+		when(decoraManagerMock.decorateRequest(httpServletRequestMock)).thenReturn(false);
+
+		// when
+		decoraServletFilter.doFilter(httpServletRequestMock, httpServletResponseMock, filterChainMock);
+
+		// then
+		verify(filterChainMock).doFilter(httpServletRequestMock, httpServletResponseMock);
+
+	}
+
+	@Test
+	public final void testDoFilterBufferingEnabledFalse() throws IOException, ServletException {
+		// setup
+		when(decoraManagerMock.decorateRequest(httpServletRequestMock)).thenReturn(true);
+		when(decoraResponseWrapperMock.isBufferingEnabled()).thenReturn(false);
+
+		// when
+		decoraServletFilter.doFilter(httpServletRequestMock, httpServletResponseMock, filterChainMock);
+
+		// then
+		verify(decoraResponseWrapperMock, never()).getBufferContentAsChars();
+		verify(decoraResponseWrapperMock).isBufferingEnabled();
+	}
+
+	@Test
+	public final void testDoFilterPageContentNull() throws IOException, ServletException {
+		// setup
+		when(decoraManagerMock.decorateRequest(httpServletRequestMock)).thenReturn(true);
+		when(decoraResponseWrapperMock.isBufferingEnabled()).thenReturn(true);
+		when(decoraResponseWrapperMock.getBufferContentAsChars()).thenReturn(null);
+
+		// when
+		decoraServletFilter.doFilter(httpServletRequestMock, httpServletResponseMock, filterChainMock);
+
+		// then
+		verify(decoraResponseWrapperMock, never()).commitResponse();
+		verify(decoraResponseWrapperMock).isBufferingEnabled();
+	}
+
+	@Test
+	public final void testDoFilterPageContentEmpty() throws IOException, ServletException {
+		// setup
+		when(decoraManagerMock.decorateRequest(httpServletRequestMock)).thenReturn(true);
+		when(decoraResponseWrapperMock.isBufferingEnabled()).thenReturn(true);
+		when(decoraResponseWrapperMock.getBufferContentAsChars()).thenReturn(new char[] {});
+
+		// when
+		decoraServletFilter.doFilter(httpServletRequestMock, httpServletResponseMock, filterChainMock);
+
+		// then
+		verify(decoraResponseWrapperMock, never()).commitResponse();
+		verify(decoraResponseWrapperMock).isBufferingEnabled();
+	}
+
+	@Test
+	public final void testDoFilterDecoratorPathNotNull() throws IOException, ServletException {
+		// setup
+		when(decoraManagerMock.decorateRequest(httpServletRequestMock)).thenReturn(true);
+		when(decoraManagerMock.resolveDecorator(httpServletRequestMock, null)).thenReturn("TEST");
+		when(decoraResponseWrapperMock.isBufferingEnabled()).thenReturn(true);
+		when(decoraResponseWrapperMock.getBufferContentAsChars()).thenReturn("TEST".toCharArray());
+
+		// when
+		decoraServletFilter.doFilter(httpServletRequestMock, httpServletResponseMock, filterChainMock);
+
+		// then
+		verify(printWriterMock).flush();
+	}
+
+	@Test
+	public final void testDoFilterDecoratorPathNull() throws IOException, ServletException {
+		// setup
+		when(decoraManagerMock.decorateRequest(httpServletRequestMock)).thenReturn(true);
+		when(decoraManagerMock.resolveDecorator(httpServletRequestMock, null)).thenReturn(null);
+		when(decoraResponseWrapperMock.isBufferingEnabled()).thenReturn(true);
+		when(decoraResponseWrapperMock.getBufferedChars()).thenReturn("TEST".toCharArray());
+		when(decoraResponseWrapperMock.getBufferContentAsChars()).thenReturn("TEST".toCharArray());
+
+		// when
+		decoraServletFilter.doFilter(httpServletRequestMock, httpServletResponseMock, filterChainMock);
+
+		// then
+		verify(httpServletResponseMock, never()).getWriter();
+		verify(decoraResponseWrapperMock).isBufferStreamBased();
+	}
+
+	@Test
+	public final void testDoFilterBufferStreamBased() throws IOException, ServletException {
+		// setup
+		when(decoraManagerMock.decorateRequest(httpServletRequestMock)).thenReturn(true);
+		when(decoraManagerMock.resolveDecorator(httpServletRequestMock, null)).thenReturn(null);
+		when(decoraResponseWrapperMock.getBufferContentAsChars()).thenReturn("TEST".toCharArray());
+		when(decoraResponseWrapperMock.isBufferingEnabled()).thenReturn(true);
+
+		// when
+		decoraServletFilter.doFilter(httpServletRequestMock, httpServletResponseMock, filterChainMock);
+
+		// then
+		verify(httpServletResponseMock).getOutputStream();
+	}
+
+}

--- a/jodd-decora/src/test/java/jodd/decora/DecoraServletFilterInitTest.java
+++ b/jodd-decora/src/test/java/jodd/decora/DecoraServletFilterInitTest.java
@@ -1,0 +1,138 @@
+// Copyright (c) 2003-present, Jodd Team (http://jodd.org)
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice,
+// this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+package jodd.decora;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
+import static org.powermock.api.mockito.PowerMockito.mock;
+import static org.powermock.api.mockito.PowerMockito.mockStatic;
+import static org.powermock.api.mockito.PowerMockito.when;
+import static org.powermock.reflect.Whitebox.getInternalState;
+import static org.powermock.reflect.Whitebox.setInternalState;
+
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import jodd.decora.parser.DecoraParser;
+import jodd.util.ClassLoaderUtil;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({ ClassLoaderUtil.class, DecoraResponseWrapper.class })
+public class DecoraServletFilterInitTest {
+
+	private DecoraServletFilter decoraServletFilter;
+	private FilterConfig filterConfigMock;
+	private DecoraParser decoraParser;
+
+	@Before
+	public void setUp() {
+		decoraServletFilter = new DecoraServletFilter();
+		filterConfigMock = mock(FilterConfig.class);
+		decoraParser = null;
+	}
+
+	@Test
+	public final void testInitManagerNullParserNull() throws ServletException {
+		// setup
+		setInternalState(decoraServletFilter, "decoraParser", decoraParser);
+		when(filterConfigMock.getInitParameter(DecoraServletFilter.PARAM_DECORA_MANAGER)).thenReturn(null);
+		when(filterConfigMock.getInitParameter(DecoraServletFilter.PARAM_DECORA_PARSER)).thenReturn(null);
+
+		// when
+		decoraServletFilter.init(filterConfigMock);
+
+		// then
+		assertNotNull("Decora parser should be set.", getInternalState(decoraServletFilter, "decoraParser"));
+	}
+
+	@Test(expected = ServletException.class)
+	public final void testInitManagerThrowException() throws ServletException {
+		// setup
+		setInternalState(decoraServletFilter, "decoraParser", decoraParser);
+		when(filterConfigMock.getInitParameter(DecoraServletFilter.PARAM_DECORA_MANAGER)).thenReturn("TEST");
+		when(filterConfigMock.getInitParameter(DecoraServletFilter.PARAM_DECORA_PARSER)).thenReturn(null);
+
+		// when
+		decoraServletFilter.init(filterConfigMock);
+
+		// then
+		fail("A ServletException must have occured because ClassLoaderUtil class shouldn't load decoraParserClass.");
+	}
+
+	@Test(expected = ServletException.class)
+	public final void testInitParserThrowException() throws ServletException {
+		// setup
+		setInternalState(decoraServletFilter, "decoraParser", decoraParser);
+		when(filterConfigMock.getInitParameter(DecoraServletFilter.PARAM_DECORA_MANAGER)).thenReturn(null);
+		when(filterConfigMock.getInitParameter(DecoraServletFilter.PARAM_DECORA_PARSER)).thenReturn("TEST");
+
+		// when
+		decoraServletFilter.init(filterConfigMock);
+
+		// then
+		fail("A ServletException must have occured because ClassLoaderUtil class shouldn't load decoraManagerClass.");
+	}
+
+	@Test
+	public final void testInitManagerSetted() throws ServletException, ClassNotFoundException {
+		// setup
+		DecoraManager decoraManager = null;
+		setInternalState(decoraServletFilter, "decoraManager", decoraManager);
+		when(filterConfigMock.getInitParameter(DecoraServletFilter.PARAM_DECORA_MANAGER)).thenReturn("TEST");
+		when(filterConfigMock.getInitParameter(DecoraServletFilter.PARAM_DECORA_PARSER)).thenReturn(null);
+		mockStatic(ClassLoaderUtil.class);
+		when(ClassLoaderUtil.loadClass("TEST")).thenReturn(DecoraManager.class);
+
+		// when
+		decoraServletFilter.init(filterConfigMock);
+
+		// then
+		assertNotNull("DecoraManager should be set.", getInternalState(decoraServletFilter, "decoraManager"));
+	}
+
+	@Test
+	public final void testInitParserSetted() throws ServletException, ClassNotFoundException {
+		// setup
+		setInternalState(decoraServletFilter, "decoraParser", decoraParser);
+		when(filterConfigMock.getInitParameter(DecoraServletFilter.PARAM_DECORA_MANAGER)).thenReturn(null);
+		when(filterConfigMock.getInitParameter(DecoraServletFilter.PARAM_DECORA_PARSER)).thenReturn("TEST");
+		mockStatic(ClassLoaderUtil.class);
+		when(ClassLoaderUtil.loadClass("TEST")).thenReturn(DecoraParser.class);
+
+		// when
+		decoraServletFilter.init(filterConfigMock);
+
+		// then
+		assertNotNull("DecoraParser should be set.", getInternalState(decoraServletFilter, "decoraParser"));
+	}
+
+}

--- a/jodd-decora/src/test/java/jodd/decora/DecoraServletFilterTest.java
+++ b/jodd-decora/src/test/java/jodd/decora/DecoraServletFilterTest.java
@@ -1,0 +1,93 @@
+// Copyright (c) 2003-present, Jodd Team (http://jodd.org)
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice,
+// this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+package jodd.decora;
+
+import static org.junit.Assert.assertNotNull;
+import static org.powermock.api.mockito.PowerMockito.mock;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import jodd.decora.parser.DecoraParser;
+import jodd.util.ClassLoaderUtil;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({ ClassLoaderUtil.class, DecoraResponseWrapper.class })
+public class DecoraServletFilterTest {
+
+	private DecoraServletFilter decoraServletFilter;
+
+	@Before
+	public void setUp() {
+		decoraServletFilter = new DecoraServletFilter();
+	}
+
+	@Test
+	public final void testCreateDecoraManager() {
+		// when
+		DecoraManager decoraManager = decoraServletFilter.createDecoraManager();
+
+		// then
+		assertNotNull("New instance should be created.", decoraManager);
+	}
+
+	@Test
+	public final void testCreateDecoraParser() {
+		// when
+		DecoraParser decoraParser = decoraServletFilter.createDecoraParser();
+
+		// then
+		assertNotNull("New instance should be created.", decoraParser);
+	}
+
+	@Test
+	public final void testDestroy() {
+		// when
+		decoraServletFilter.destroy();
+
+		// then
+		// Function body is empty
+		// No checking needed
+	}
+
+	@Test
+	public final void testWrapRequest() {
+		// setup
+		HttpServletRequest httpServletRequestMock = mock(HttpServletRequest.class);
+
+		// when
+		HttpServletRequest httpServletRequest = decoraServletFilter.wrapRequest(httpServletRequestMock);
+
+		// then
+		assertNotNull("New instance should be created.", httpServletRequest);
+	}
+
+}

--- a/jodd-decora/src/test/java/jodd/decora/parser/DecoraParserTestDecoratedPageTest.java
+++ b/jodd-decora/src/test/java/jodd/decora/parser/DecoraParserTestDecoratedPageTest.java
@@ -1,0 +1,87 @@
+// Copyright (c) 2003-present, Jodd Team (http://jodd.org)
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice,
+// this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+package jodd.decora.parser;
+
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.powermock.api.mockito.PowerMockito.mock;
+import static org.powermock.api.mockito.PowerMockito.when;
+import static org.powermock.reflect.Whitebox.invokeMethod;
+
+import java.io.Writer;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+@RunWith(PowerMockRunner.class)
+public class DecoraParserTestDecoratedPageTest {
+
+	private DecoraParser decoraParser;
+	private Writer writerMock;
+	private DecoraTag decoraTagMock;
+
+	@Before
+	public void setUp() {
+		decoraParser = new DecoraParser();
+		writerMock = mock(Writer.class);
+		decoraTagMock = mock(DecoraTag.class);
+	}
+
+	@Test
+	public void testWriteDecoratedPageDecoraTagLengthNegative() throws Exception {
+		// setup
+		when(decoraTagMock.getStartIndex()).thenReturn(-1);
+		DecoraTag[] decoraTags = { decoraTagMock };
+		char[] decoratorContent = new char[] {};
+
+		// when
+		invokeMethod(decoraParser, "writeDecoratedPage", writerMock, decoratorContent, new char[] {}, decoraTags);
+
+		// then
+		verify(decoraTagMock, never()).getEndIndex();
+		verify(writerMock).write(decoratorContent, 0, decoratorContent.length);
+	}
+
+	@Test
+	public void testWriteDecoratedPageDecoraTagRegionUndefined() throws Exception {
+		// setup
+		DecoraTag decoraTagMock2 = mock(DecoraTag.class);
+		when(decoraTagMock.isRegionUndefined()).thenReturn(true);
+		when(decoraTagMock.getRegionStart()).thenReturn(0);
+		when(decoraTagMock.getRegionLength()).thenReturn(10);
+		DecoraTag[] decoraTags = { decoraTagMock2 };
+		char[] pageContent = new char[] {};
+
+		// when
+		invokeMethod(decoraParser, "writeRegion", writerMock, pageContent, decoraTagMock, decoraTags);
+
+		// then
+		verify(decoraTagMock2, never()).isInsideOtherTagRegion(decoraTagMock);
+		verify(writerMock).write(pageContent, 0, 10);
+	}
+}

--- a/jodd-decora/src/test/java/jodd/decora/parser/DecoraTagTest.java
+++ b/jodd-decora/src/test/java/jodd/decora/parser/DecoraTagTest.java
@@ -1,0 +1,91 @@
+// Copyright (c) 2003-present, Jodd Team (http://jodd.org)
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice,
+// this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+package jodd.decora.parser;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.powermock.reflect.Whitebox.setInternalState;
+
+import org.junit.Before;
+import org.junit.Test;
+
+public class DecoraTagTest {
+
+	private DecoraTag decoraTag;
+
+	@Before
+	public void setUp() {
+		decoraTag = new DecoraTag("TEST", "TEST", 0, 1);
+	}
+
+	@Test
+	public final void testDuplicate() {
+		// when
+		DecoraTag duplicatedDecoraTag = decoraTag.duplicate();
+
+		// then
+		assertNotNull("Return value of duplicate function shouldn't be null.", duplicatedDecoraTag);
+	}
+
+	@Test
+	public final void testIsRegionDefinedTrue() {
+		// when
+		setInternalState(decoraTag, "regionLength", 1);
+
+		// then
+		assertTrue("Region length is 1. Must return true.", decoraTag.isRegionDefined());
+	}
+
+	@Test
+	public final void testIsRegionDefinedFalse() {
+		// when
+		setInternalState(decoraTag, "regionLength", 0);
+
+		// then
+		assertFalse("Region length is 0. Must return false.", decoraTag.isRegionDefined());
+	}
+
+	@Test
+	public final void testGetDeepLevel() {
+		// when
+		setInternalState(decoraTag, "deepLevel", 0);
+
+		// then
+		assertEquals("DeepLevel must be 0 at this line.", 0, decoraTag.getDeepLevel());
+	}
+
+	@Test
+	public final void testToString() {
+		// when
+		String toString = decoraTag.toString();
+
+		// then
+		assertNotNull("ToString method shouldn't return null.", toString);
+	}
+
+}

--- a/jodd-decora/src/test/java/jodd/decora/parser/DecoratorTagVisitorTest.java
+++ b/jodd-decora/src/test/java/jodd/decora/parser/DecoratorTagVisitorTest.java
@@ -1,0 +1,71 @@
+// Copyright (c) 2003-present, Jodd Team (http://jodd.org)
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice,
+// this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+package jodd.decora.parser;
+
+import static org.junit.Assert.fail;
+import static org.powermock.reflect.Whitebox.invokeMethod;
+import static org.powermock.reflect.Whitebox.setInternalState;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import jodd.decora.DecoraException;
+
+public class DecoratorTagVisitorTest {
+
+	private DecoratorTagVisitor decoraTagVisitor;
+
+	@Before
+	public void setUp() {
+		decoraTagVisitor = new DecoratorTagVisitor();
+	}
+
+	@Test(expected = DecoraException.class)
+	public final void testCheckNestedDecoraTagsDecoraTagNameNotNull() throws Exception {
+		// setup
+		setInternalState(decoraTagVisitor, "decoraTagName", "TEST");
+
+		// when
+		invokeMethod(decoraTagVisitor, "checkNestedDecoraTags");
+
+		// then
+		fail("A DecoraException must have occured because decoraTagName is not null.");
+	}
+
+	@Test
+	public final void testCheckNestedDecoraTagsDecoraTagNameNull() throws Exception {
+		// setup
+		String nullString = null;
+		setInternalState(decoraTagVisitor, "decoraTagName", nullString);
+
+		// when
+		invokeMethod(decoraTagVisitor, "checkNestedDecoraTags");
+
+		// then
+		// DecoraException not expected
+	}
+
+}

--- a/jodd-decora/src/test/java/jodd/decora/parser/PageRegionExtractorTest.java
+++ b/jodd-decora/src/test/java/jodd/decora/parser/PageRegionExtractorTest.java
@@ -1,0 +1,93 @@
+// Copyright (c) 2003-present, Jodd Team (http://jodd.org)
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice,
+// this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+package jodd.decora.parser;
+
+import static org.junit.Assert.fail;
+import static org.powermock.api.mockito.PowerMockito.mock;
+import static org.powermock.api.mockito.PowerMockito.when;
+import static org.powermock.reflect.Whitebox.setInternalState;
+
+import java.util.LinkedList;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import jodd.decora.DecoraException;
+import jodd.decora.parser.PageRegionExtractor.RegionMarker;
+import jodd.lagarto.Tag;
+import jodd.lagarto.TagType;
+
+public class PageRegionExtractorTest {
+
+	private PageRegionExtractor pageRegionExtractor;
+	private LinkedList<RegionMarker> regionMarkers;
+
+	@Before
+	public void setUp() {
+		pageRegionExtractor = new PageRegionExtractor(new DecoraTag[] {});
+		regionMarkers = new LinkedList<>();
+	}
+
+	@Test(expected = DecoraException.class)
+	public final void testEndRegionMarkersNotEmpty() {
+		// setup
+		regionMarkers.add(new RegionMarker("TEST"));
+		setInternalState(pageRegionExtractor, "regionMarkers", regionMarkers);
+
+		// when
+		pageRegionExtractor.end();
+
+		// then
+		fail("A DecorationException must have occured because regionMarkers is not empty.");
+	}
+
+	public final void testEndRegionMarkersEmpty() {
+		// setup
+		setInternalState(pageRegionExtractor, "regionMarkers", regionMarkers);
+
+		// when
+		pageRegionExtractor.end();
+
+		// then
+		// DecoraException not expected
+	}
+
+	@Test(expected = DecoraException.class)
+	public final void testTag() {
+		// setup
+		Tag tag = mock(Tag.class);
+		when(tag.getType()).thenReturn(TagType.END);
+		regionMarkers.add(new RegionMarker("TEST"));
+		setInternalState(pageRegionExtractor, "regionMarkers", regionMarkers);
+
+		// when
+		pageRegionExtractor.tag(tag);
+
+		// then
+		fail("A DecoraException must have occured because tag parameter not matches with any decoraTags.");
+	}
+
+}


### PR DESCRIPTION
This pull request is focused on package `jodd.decora`. Code coverage is measured using JaCoCo. This pull request increases code coverage of the whole project by 1%.

Metric | Before | After
------ | ------ | -----
Coverage % | 70% | 71%
Lines Covered | 26.495 | 26.588
Total Lines | 38,780 | 38,780

Please let me know if you have any questions.

Furkan
DevFactory - Code Quality Team