### PR TITLE
squid:S1698 - Objects should be compared with 'equals()'

### DIFF
--- a/jodd-core/src/main/java/jodd/io/FileNameUtil.java
+++ b/jodd-core/src/main/java/jodd/io/FileNameUtil.java
@@ -923,7 +923,7 @@ public class FileNameUtil {
 	 */
 	private static boolean equals(String filename1, String filename2, boolean system) {
 		//noinspection StringEquality
-		if (filename1 == filename2) {
+		if (filename1 != null && filename1.equals(filename2)) {
 			return true;
 		}
 		if (filename1 == null || filename2 == null) {

--- a/jodd-core/src/main/java/jodd/util/ClassLoaderUtil.java
+++ b/jodd-core/src/main/java/jodd/util/ClassLoaderUtil.java
@@ -460,7 +460,7 @@ public class ClassLoaderUtil {
 
 		// try #2 - using thread class loader
 		ClassLoader currentThreadClassLoader = Thread.currentThread().getContextClassLoader();
-		if ((currentThreadClassLoader != null) && (currentThreadClassLoader != classLoader)) {
+		if (currentThreadClassLoader != null && !currentThreadClassLoader.equals(classLoader)) {
 			resourceUrl = currentThreadClassLoader.getResource(resourceName);
 			if (resourceUrl != null) {
 				return resourceUrl;
@@ -471,7 +471,9 @@ public class ClassLoaderUtil {
 		Class callerClass = ReflectUtil.getCallerClass(2);
 		ClassLoader callerClassLoader = callerClass.getClassLoader();
 
-		if ((callerClassLoader != classLoader) && (callerClassLoader != currentThreadClassLoader)) {
+		if (callerClassLoader != null
+				&& (!callerClassLoader.equals(classLoader))
+				&& (!callerClassLoader.equals(currentThreadClassLoader))) {
 			resourceUrl = callerClassLoader.getResource(resourceName);
 			if (resourceUrl != null) {
 				return resourceUrl;

--- a/jodd-core/src/main/java/jodd/util/cl/DefaultClassLoaderStrategy.java
+++ b/jodd-core/src/main/java/jodd/util/cl/DefaultClassLoaderStrategy.java
@@ -152,7 +152,7 @@ public class DefaultClassLoaderStrategy implements ClassLoaderStrategy {
 		// try #2 - using thread class loader
 		ClassLoader currentThreadClassLoader = Thread.currentThread().getContextClassLoader();
 
-		if ((currentThreadClassLoader != null) && (currentThreadClassLoader != classLoader)) {
+		if ( currentThreadClassLoader != null && !currentThreadClassLoader.equals(classLoader) ) {
 			Class klass = loadClass(className, arrayClassName, currentThreadClassLoader);
 
 			if (klass != null) {
@@ -165,7 +165,8 @@ public class DefaultClassLoaderStrategy implements ClassLoaderStrategy {
 		Class callerClass = ReflectUtil.getCallerClass();
 		ClassLoader callerClassLoader = callerClass.getClassLoader();
 
-		if ((callerClassLoader != classLoader) && (callerClassLoader != currentThreadClassLoader)) {
+		if (callerClassLoader != null && !callerClassLoader.equals(classLoader)
+				&& !callerClassLoader.equals(currentThreadClassLoader)) {
 			Class klass = loadClass(className, arrayClassName, callerClassLoader);
 
 			if (klass != null) {

--- a/jodd-core/src/main/java/jodd/util/collection/IntHashMap.java
+++ b/jodd-core/src/main/java/jodd/util/collection/IntHashMap.java
@@ -756,7 +756,7 @@ public class IntHashMap extends AbstractMap implements Cloneable, Serializable {
 
 			for (Entry e = tab[ndx], prev = null; e != null;
 				 prev = e, e = e.next) {
-				if (e == lastReturned) {
+				if (e.equals(lastReturned)) {
 					modCount++;
 					expectedModCount++;
 					if (prev == null) {

--- a/jodd-core/src/main/java/jodd/util/collection/SetMapAdapter.java
+++ b/jodd-core/src/main/java/jodd/util/collection/SetMapAdapter.java
@@ -107,7 +107,7 @@ public abstract class SetMapAdapter<E> extends AbstractSet<E> {
 	 */
 	@Override
 	public boolean remove(Object o) {
-		return map.remove(o) == DUMMY_VALUE;
+		return map.remove(o).equals(DUMMY_VALUE);
 	}
 
 	/**

--- a/jodd-http/src/main/java/jodd/http/HttpMultiMap.java
+++ b/jodd-http/src/main/java/jodd/http/HttpMultiMap.java
@@ -160,7 +160,7 @@ public class HttpMultiMap<V> implements Iterable<Map.Entry<String, V>>  {
 	 * Returns <code>true</code> if map is empty.
 	 */
 	public boolean isEmpty() {
-		return head == head.after;
+		return head.equals(head.after);
 	}
 
 	public String toString() {
@@ -361,7 +361,7 @@ public class HttpMultiMap<V> implements Iterable<Map.Entry<String, V>>  {
 		return new Iterator<Map.Entry<String, V>>() {
 			@Override
 			public boolean hasNext() {
-				return e[0] != head;
+				return !e[0].equals(head);
 			}
 
 			@Override
@@ -386,7 +386,7 @@ public class HttpMultiMap<V> implements Iterable<Map.Entry<String, V>>  {
 		Set<String> names = new TreeSet<>(caseSensitive ? null : String.CASE_INSENSITIVE_ORDER);
 
 		MapEntry e = head.after;
-		while (e != head) {
+		while (!e.equals(head)) {
 			names.add(e.getKey());
 			e = e.after;
 		}
@@ -401,7 +401,7 @@ public class HttpMultiMap<V> implements Iterable<Map.Entry<String, V>>  {
 		List<Map.Entry<String, V>> all = new LinkedList<>();
 
 		MapEntry<V> e = head.after;
-		while (e != head) {
+		while (!e.equals(head)) {
 			all.add(e);
 			e = e.after;
 		}

--- a/jodd-json/src/main/java/jodd/json/JsonContext.java
+++ b/jodd-json/src/main/java/jodd/json/JsonContext.java
@@ -81,7 +81,7 @@ public class JsonContext extends JsonWriter {
 	public boolean pushValue(Object value) {
 		for (int i = 0; i < bagSize; i++) {
 			JsonValueContext valueContext = bag.get(i);
-			if (valueContext.getValue() == value) {
+			if (valueContext.getValue() != null && valueContext.getValue().equals(value)) {
 				return true;
 			}
 		}

--- a/jodd-json/src/main/java/jodd/json/MapToBean.java
+++ b/jodd-json/src/main/java/jodd/json/MapToBean.java
@@ -193,7 +193,7 @@ public class MapToBean {
 				Object value = entry.getValue();
 				Object newValue = convert(value, valueType);
 
-				if (value != newValue) {
+				if (!newValue.equals(value)) {
 					entry.setValue(newValue);
 				}
 			}

--- a/jodd-lagarto/src/main/java/jodd/lagarto/adapter/UrlRewriterTagAdapter.java
+++ b/jodd-lagarto/src/main/java/jodd/lagarto/adapter/UrlRewriterTagAdapter.java
@@ -52,7 +52,7 @@ public abstract class UrlRewriterTagAdapter extends TagAdapter {
 				if (href != null) {
 					CharSequence newHref = rewriteUrl(href);
 
-					if (newHref != href) {
+					if (!href.equals(newHref)) {
 						tag.setAttribute("href", newHref);
 					}
 				}

--- a/jodd-lagarto/src/main/java/jodd/lagarto/dom/Node.java
+++ b/jodd-lagarto/src/main/java/jodd/lagarto/dom/Node.java
@@ -302,7 +302,7 @@ public abstract class Node implements Cloneable {
 	 * if provided child node is not a child nothing happens.
 	 */
 	public void removeChild(Node childNode) {
-		if (childNode.getParentNode() != this) {
+		if (!this.equals(childNode.getParentNode())) {
 			return;
 		}
 		childNode.detachFromParent();
@@ -711,8 +711,8 @@ public abstract class Node implements Cloneable {
 			int childCount = getChildNodesCount();
 			for (int i = 0; i < childCount; i++) {
 				Node child = getChild(i);
-				if (child.siblingElementIndex >= 0) {
-					if (childElementNodes[child.siblingElementIndex] != child) {
+				if (child != null && child.siblingElementIndex >= 0) {
+					if (!child.equals(childElementNodes[child.siblingElementIndex])) {
 						return false;
 					}
 				}

--- a/jodd-petite/src/test/java/jodd/petite/MiscTest.java
+++ b/jodd-petite/src/test/java/jodd/petite/MiscTest.java
@@ -215,7 +215,7 @@ public class MiscTest {
 
 		BeanOne petiteBean = pc.getBean(BeanOne.class);
 
-		assertTrue(petiteBean.ctor != petiteBean.setter);
+		assertTrue(petiteBean.ctor != null && !petiteBean.ctor.equals(petiteBean.setter));
 	}
 
 }

--- a/jodd-proxetta/src/main/java/jodd/asm5/ClassReader.java
+++ b/jodd-proxetta/src/main/java/jodd/asm5/ClassReader.java
@@ -921,7 +921,7 @@ public class ClassReader {
          */
         if (WRITER && mv instanceof MethodWriter) {
             MethodWriter mw = (MethodWriter) mv;
-            if (mw.cw.cr == this && signature == mw.signature) {
+            if ( (this.equals(mw.cw.cr)) && (signature != null && signature.equals(mw.signature)) ) {
                 boolean sameExceptions = false;
                 if (exceptions == null) {
                     sameExceptions = mw.exceptionCount == 0;

--- a/jodd-swingspy/src/main/java/jodd/swingspy/SwingSpyGlassPane.java
+++ b/jodd-swingspy/src/main/java/jodd/swingspy/SwingSpyGlassPane.java
@@ -91,7 +91,7 @@ public class SwingSpyGlassPane extends JPanel implements AWTEventListener {
             if (SwingUtilities.isDescendingFrom(mecmp, (Component) rootPaneContainer) == false) {
                 return;
             }
-            if ((me.getID() == MouseEvent.MOUSE_EXITED) && (mecmp == rootPaneContainer)) {
+            if ( me.getID() == MouseEvent.MOUSE_EXITED && (mecmp != null && mecmp.equals(rootPaneContainer)) ) {
                 highcmp = null;
                 point = null;
             } else {
@@ -102,7 +102,7 @@ public class SwingSpyGlassPane extends JPanel implements AWTEventListener {
                 rect.width = mecmp.getWidth();
                 rect.height = mecmp.getHeight();
                 Rectangle parentBounds = new Rectangle();
-                while ((parent != null) && (parent != this.getRootPane()) && (parent != rootPaneContainer)) {
+                while ( parent != null && parent.equals(this.getRootPane()) && !parent.equals(rootPaneContainer) ) {
                     parent.getBounds(parentBounds);
                     rect.x += parentBounds.x;
                     rect.y += parentBounds.y;
@@ -121,9 +121,9 @@ public class SwingSpyGlassPane extends JPanel implements AWTEventListener {
      */
     @Override
     public boolean contains(int x, int y) {
-        if (getMouseListeners().length == 0 && getMouseMotionListeners().length == 0
+        if ( getMouseListeners().length == 0 && getMouseMotionListeners().length == 0
                 && getMouseWheelListeners().length == 0
-                && getCursor() == Cursor.getPredefinedCursor(Cursor.DEFAULT_CURSOR)) {
+                && (getCursor() != null && getCursor().equals(Cursor.getPredefinedCursor(Cursor.DEFAULT_CURSOR))) ) {
             return false;
         }
         return super.contains(x, y);

--- a/jodd-swingspy/src/main/java/jodd/swingspy/SwingSpyPanel.java
+++ b/jodd-swingspy/src/main/java/jodd/swingspy/SwingSpyPanel.java
@@ -143,7 +143,7 @@ public class SwingSpyPanel extends JPanel {
 	protected void addNode(DefaultMutableTreeNode parent, Component component, Component selectedComponent) {
 		DefaultMutableTreeNode componentNode = new DefaultMutableTreeNode(new ComponentWrapper(component));
 		parent.add(componentNode);
-		if (component == selectedComponent) {
+		if (component != null && component.equals(selectedComponent)) {
 			TreePath selectedPath = new TreePath(componentNode.getPath());
 			componentTree.setSelectionPath(selectedPath);
 			componentTree.scrollPathToVisible(selectedPath);


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1698 - Objects should be compared with 'equals()'
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid:S1698
Please let me know if you have any questions.
M-Ezzat