### PR TITLE
squid:S2063 - Comparators should be "Serializable"

### DIFF
--- a/jodd-core/src/main/java/jodd/io/findfile/FindFile.java
+++ b/jodd-core/src/main/java/jodd/io/findfile/FindFile.java
@@ -25,23 +25,24 @@
 
 package jodd.io.findfile;
 
-import jodd.io.FileNameUtil;
-import jodd.util.InExRules;
-import jodd.util.MultiComparator;
-import jodd.util.NaturalOrderComparator;
-import jodd.util.StringUtil;
-import jodd.io.FileUtil;
-import jodd.util.collection.JoddArrayList;
-
 import java.io.File;
+import java.io.Serializable;
+import java.net.URI;
+import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.Iterator;
-import java.net.URI;
-import java.net.URL;
 import java.util.List;
 import java.util.NoSuchElementException;
+
+import jodd.io.FileNameUtil;
+import jodd.io.FileUtil;
+import jodd.util.InExRules;
+import jodd.util.MultiComparator;
+import jodd.util.NaturalOrderComparator;
+import jodd.util.StringUtil;
+import jodd.util.collection.JoddArrayList;
 
 /**
  * Generic iterative file finder. Searches all files on specified search path.
@@ -762,7 +763,8 @@ public class FindFile<T extends FindFile> {
 
 	// ---------------------------------------------------------------- comparators
 
-	public static class FolderFirstComparator implements Comparator<File> {
+	public static class FolderFirstComparator implements Comparator<File>, Serializable {
+		private static final long serialVersionUID = 1;
 
 		protected final int order;
 
@@ -785,7 +787,8 @@ public class FindFile<T extends FindFile> {
 		}
 	}
 
-	public static class FileNameComparator implements Comparator<File> {
+	public static class FileNameComparator implements Comparator<File>, Serializable {
+		private static final long serialVersionUID = 1;
 
 		protected final int order;
 		protected NaturalOrderComparator<String> naturalOrderComparator = new NaturalOrderComparator<>(true);
@@ -810,7 +813,8 @@ public class FindFile<T extends FindFile> {
 		}
 	}
 
-	public static class FileExtensionComparator implements Comparator<File> {
+	public static class FileExtensionComparator implements Comparator<File>, Serializable {
+		private static final long serialVersionUID = 1;
 
 		protected final int order;
 
@@ -836,7 +840,8 @@ public class FindFile<T extends FindFile> {
 		}
 	}
 
-	public static class FileLastModifiedTimeComparator implements Comparator<File> {
+	public static class FileLastModifiedTimeComparator implements Comparator<File>, Serializable {
+		private static final long serialVersionUID = 1;
 
 		protected final int order;
 

--- a/jodd-core/src/main/java/jodd/util/ComparableComparator.java
+++ b/jodd-core/src/main/java/jodd/util/ComparableComparator.java
@@ -25,13 +25,15 @@
 
 package jodd.util;
 
+import java.io.Serializable;
 import java.util.Comparator;
 
 
 /**
  * Comparator that adapts <code>Comparables</code> to the <code>Comparator</code> interface.
  */
-public class ComparableComparator<T extends Comparable<T>> implements Comparator<T> {
+public class ComparableComparator<T extends Comparable<T>> implements Comparator<T>, Serializable {
+	private static final long serialVersionUID = 1;
 
 	/**
 	 * Cached instance.

--- a/jodd-core/src/main/java/jodd/util/MultiComparator.java
+++ b/jodd-core/src/main/java/jodd/util/MultiComparator.java
@@ -25,13 +25,15 @@
 
 package jodd.util;
 
+import java.io.Serializable;
 import java.util.Comparator;
 import java.util.List;
 
 /**
  * Multiple comparators compares using list of comparators.
  */
-public class MultiComparator<T> implements Comparator<T> {
+public class MultiComparator<T> implements Comparator<T>, Serializable {
+	private static final long serialVersionUID = 1;
 
 	protected final List<Comparator<T>> comparators;
 

--- a/jodd-core/src/main/java/jodd/util/NaturalOrderComparator.java
+++ b/jodd-core/src/main/java/jodd/util/NaturalOrderComparator.java
@@ -25,12 +25,14 @@
 
 package jodd.util;
 
+import java.io.Serializable;
 import java.util.Comparator;
 
 /**
  * Compares two strings in natural, alphabetical, way.
  */
-public class NaturalOrderComparator<T> implements Comparator<T> {
+public class NaturalOrderComparator<T> implements Comparator<T>, Serializable {
+	private static final long serialVersionUID = 1;
 
 	protected final boolean ignoreCase;
 

--- a/jodd-madvoc/src/main/java/jodd/madvoc/component/ActionsManager.java
+++ b/jodd-madvoc/src/main/java/jodd/madvoc/component/ActionsManager.java
@@ -39,6 +39,7 @@ import jodd.util.collection.SortedArrayList;
 import jodd.log.Logger;
 import jodd.log.LoggerFactory;
 
+import java.io.Serializable;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -80,7 +81,8 @@ public class ActionsManager {
 	/**
 	 * Comparator that considers first chunks number then action path.
 	 */
-	public static class ActionConfigSetComparator implements Comparator<ActionConfigSet> {
+	public static class ActionConfigSetComparator implements Comparator<ActionConfigSet>, Serializable {
+		private static final long serialVersionUID = 1;
 
 		public int compare(ActionConfigSet set1, ActionConfigSet set2) {
 			int deep1 = set1.deep;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2063
- Comparators should be "Serializable"
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid:S2063
Please let me know if you have any questions.
M-Ezzat