### PR TITLE
squid:S1157 - Case insensitive string comparisons should be made without intermediate upper or lower casing

### DIFF
--- a/jodd-core/src/main/java/jodd/util/SystemUtil.java
+++ b/jodd-core/src/main/java/jodd/util/SystemUtil.java
@@ -436,7 +436,7 @@ public class SystemUtil {
 	 * Returns <code>true</code> if host is AIX.
 	 */
 	public static boolean isHostAix() {
-		return osName().toUpperCase().equals("AIX");
+		return osName().equalsIgnoreCase("AIX");
 	}
 
 	/**

--- a/jodd-madvoc/src/main/java/jodd/madvoc/MadvocResponseWrapper.java
+++ b/jodd-madvoc/src/main/java/jodd/madvoc/MadvocResponseWrapper.java
@@ -68,7 +68,7 @@ public class MadvocResponseWrapper extends HttpServletResponseWrapper {
 
 	@Override
 	public void setHeader(String name, String value) {
-		if (name.toLowerCase().equals(CONTENT_TYPE)) {
+		if (name.equalsIgnoreCase(CONTENT_TYPE)) {
 			setContentType(value);
 		} else {
 			super.setHeader(name, value);
@@ -77,7 +77,7 @@ public class MadvocResponseWrapper extends HttpServletResponseWrapper {
 
 	@Override
 	public void addHeader(String name, String value) {
-		if (name.toLowerCase().equals(CONTENT_TYPE)) {
+		if (name.equalsIgnoreCase(CONTENT_TYPE)) {
 			setContentType(value);
 		} else {
 			super.addHeader(name, value);

--- a/jodd-servlet/src/main/java/jodd/servlet/wrapper/BufferResponseWrapper.java
+++ b/jodd-servlet/src/main/java/jodd/servlet/wrapper/BufferResponseWrapper.java
@@ -386,7 +386,7 @@ public class BufferResponseWrapper extends HttpServletResponseWrapper {
 	 */
 	@Override
 	public void setIntHeader(String name, int value) {
-		if (buffer == null || !name.toLowerCase().equals(CONTENT_LENGTH)) {
+		if (buffer == null || !name.equalsIgnoreCase(CONTENT_LENGTH)) {
 			super.setIntHeader(name, value);
 		}
 	}
@@ -396,7 +396,7 @@ public class BufferResponseWrapper extends HttpServletResponseWrapper {
 	 */
 	@Override
 	public void addIntHeader(String name, int value) {
-		if (buffer == null || !name.toLowerCase().equals(CONTENT_LENGTH)) {
+		if (buffer == null || !name.equalsIgnoreCase(CONTENT_LENGTH)) {
 			super.addIntHeader(name, value);
 		}
 	}
@@ -405,7 +405,7 @@ public class BufferResponseWrapper extends HttpServletResponseWrapper {
 
 	@Override
 	public void setDateHeader(String name, long value) {
-		if (name.toLowerCase().equals(LAST_MODIFIED)) {
+		if (name.equalsIgnoreCase(LAST_MODIFIED)) {
 			lastModifiedData.updateLastModified(value);
 		} else {
 			super.setDateHeader(name, value);
@@ -414,7 +414,7 @@ public class BufferResponseWrapper extends HttpServletResponseWrapper {
 
 	@Override
 	public void addDateHeader(String name, long value) {
-		if (name.toLowerCase().equals(LAST_MODIFIED)) {
+		if (name.equalsIgnoreCase(LAST_MODIFIED)) {
 			lastModifiedData.updateLastModified(value);
 		} else {
 			super.addDateHeader(name, value);


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1157
- Case insensitive string comparisons should be made without intermediate upper or lower casing
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid:S1157
Please let me know if you have any questions.
M-Ezzat