### PR TITLE
squid:S2162 -  equals methods should be symmetric and work for subcla…

### DIFF
--- a/jodd-core/src/main/java/jodd/datetime/DateTimeStamp.java
+++ b/jodd-core/src/main/java/jodd/datetime/DateTimeStamp.java
@@ -240,7 +240,7 @@ public class DateTimeStamp implements Comparable, Serializable, Cloneable {
 		if (this == object) {
 			return true;
 		}
-		if (!(object instanceof DateTimeStamp)) {
+		if (this.getClass() != object.getClass()) {
 			return false;
 		}
 		DateTimeStamp stamp = (DateTimeStamp) object;

--- a/jodd-core/src/main/java/jodd/datetime/JDateTime.java
+++ b/jodd-core/src/main/java/jodd/datetime/JDateTime.java
@@ -1618,7 +1618,7 @@ public class JDateTime implements Comparable, Cloneable, Serializable {
 		if (this == obj) {
 			return true;
 		}
-		if (!(obj instanceof JDateTime)) {
+		if (this.getClass() != obj.getClass()) {
 			return false;
 		}
 		JDateTime jdt = (JDateTime) obj;

--- a/jodd-core/src/main/java/jodd/datetime/JulianDateStamp.java
+++ b/jodd-core/src/main/java/jodd/datetime/JulianDateStamp.java
@@ -272,7 +272,7 @@ public class JulianDateStamp implements Serializable, Cloneable {
 		if (this == object) {
 			return true;
 		}
-		if (!(object instanceof JulianDateStamp)) {
+		if (this.getClass() != object.getClass()) {
 			return false;
 		}
 		JulianDateStamp stamp = (JulianDateStamp) object;

--- a/jodd-core/src/main/java/jodd/mutable/MutableBoolean.java
+++ b/jodd-core/src/main/java/jodd/mutable/MutableBoolean.java
@@ -104,10 +104,10 @@ public final class MutableBoolean implements Comparable<MutableBoolean>, Cloneab
 	@Override
 	public boolean equals(Object obj) {
 		if (obj != null) {
-			if (obj instanceof Boolean) {
+			if ( ((Boolean)this.value).getClass() == obj.getClass() ) {
 				return value == ((Boolean) obj).booleanValue();
 			}
-			if (obj instanceof MutableBoolean) {
+			if (this.getClass() == obj.getClass()) {
 				return value == ((MutableBoolean) obj).value;
 			}
 		}

--- a/jodd-core/src/main/java/jodd/mutable/MutableByte.java
+++ b/jodd-core/src/main/java/jodd/mutable/MutableByte.java
@@ -101,10 +101,10 @@ public final class MutableByte extends Number implements Comparable<MutableByte>
 	@Override
 	public boolean equals(Object obj) {
 		if (obj != null) {
-			if (obj instanceof Byte) {
+			if ( ((Byte)this.value).getClass() == obj.getClass() ) {
 				return value == ((Byte) obj).byteValue();
 			}
-			if (obj instanceof MutableByte) {
+			if (this.getClass() == obj.getClass()) {
 				return value == ((MutableByte) obj).value;
 			}
 		}

--- a/jodd-core/src/main/java/jodd/mutable/MutableDouble.java
+++ b/jodd-core/src/main/java/jodd/mutable/MutableDouble.java
@@ -102,10 +102,10 @@ public final class MutableDouble extends Number implements Comparable<MutableDou
 	@Override
 	public boolean equals(Object obj) {
 		if (obj != null) {
-			if (obj instanceof Double) {
+			if ( ((Double)this.value).getClass() == obj.getClass() ) {
 				return Double.doubleToLongBits(value) == Double.doubleToLongBits(((Double) obj).doubleValue());
 			}
-			if (obj instanceof MutableDouble) {
+			if (this.getClass() == obj.getClass()) {
 				return Double.doubleToLongBits(value) == Double.doubleToLongBits(((MutableDouble) obj).value);
 			}
 		}

--- a/jodd-core/src/main/java/jodd/mutable/MutableFloat.java
+++ b/jodd-core/src/main/java/jodd/mutable/MutableFloat.java
@@ -101,10 +101,10 @@ public final class MutableFloat extends Number implements Comparable<MutableFloa
 	@Override
 	public boolean equals(Object obj) {
 		if (obj != null) {
-			if (obj instanceof Float) {
+			if ( ((Float)this.value).getClass() == obj.getClass() ) {
 				return Float.floatToIntBits(value) == Float.floatToIntBits(((Float) obj).floatValue());
 			}
-			if (obj instanceof MutableFloat) {
+			if (this.getClass() == obj.getClass()) {
 				return Float.floatToIntBits(value) == Float.floatToIntBits(((MutableFloat) obj).value);
 			}
 		}

--- a/jodd-core/src/main/java/jodd/mutable/MutableInteger.java
+++ b/jodd-core/src/main/java/jodd/mutable/MutableInteger.java
@@ -101,10 +101,10 @@ public final class MutableInteger extends Number implements Comparable<MutableIn
 	@Override
 	public boolean equals(Object obj) {
 		if (obj != null) {
-			if (obj instanceof Integer) {
+			if ( ((Integer)this.value).getClass() == obj.getClass() ) {
 				return value == ((Integer) obj).intValue();
 			}
-			if (obj instanceof MutableInteger) {
+			if (this.getClass() == obj.getClass()) {
 				return value == ((MutableInteger) obj).value;
 			}
 		}

--- a/jodd-core/src/main/java/jodd/mutable/MutableLong.java
+++ b/jodd-core/src/main/java/jodd/mutable/MutableLong.java
@@ -101,10 +101,10 @@ public final class MutableLong extends Number implements Comparable<MutableLong>
 	@Override
 	public boolean equals(Object obj) {
 		if (obj != null) {
-			if (obj instanceof Long) {
+			if ( ((Long)this.value).getClass() == obj.getClass() ) {
 				return value == ((Long) obj).longValue();
 			}
-			if (obj instanceof MutableLong) {
+			if (this.getClass() == obj.getClass()) {
 				return value == ((MutableLong) obj).value;
 			}
 		}

--- a/jodd-core/src/main/java/jodd/mutable/MutableShort.java
+++ b/jodd-core/src/main/java/jodd/mutable/MutableShort.java
@@ -101,10 +101,10 @@ public final class MutableShort extends Number implements Comparable<MutableShor
 	@Override
 	public boolean equals(Object obj) {
 		if (obj != null) {
-			if (obj instanceof Short) {
+			if ( ((Short)this.value).getClass() == obj.getClass() ) {
 				return value == ((Short) obj).shortValue();
 			}
-			if (obj instanceof MutableShort) {
+			if (this.getClass() == obj.getClass()) {
 				return value == ((MutableShort) obj).value;
 			}
 		}

--- a/jodd-core/src/main/java/jodd/util/NameValue.java
+++ b/jodd-core/src/main/java/jodd/util/NameValue.java
@@ -71,7 +71,7 @@ public class NameValue<N, V> {
 
 	@Override
 	public boolean equals(Object o) {
-		if (!(o instanceof NameValue)) {
+		if (this.getClass() != o.getClass()) {
 			return false;
 		}
 		NameValue that = (NameValue) o;

--- a/jodd-core/src/main/java/jodd/util/collection/IntHashMap.java
+++ b/jodd-core/src/main/java/jodd/util/collection/IntHashMap.java
@@ -674,7 +674,7 @@ public class IntHashMap extends AbstractMap implements Cloneable, Serializable {
 
 		@Override
 		public boolean equals(Object o) {
-			if (!(o instanceof Map.Entry)) {
+			if (this.getClass() != o.getClass()) {
 				return false;
 			}
 			Map.Entry e = (Map.Entry) o;

--- a/jodd-db/src/main/java/jodd/db/DbTransactionMode.java
+++ b/jodd-db/src/main/java/jodd/db/DbTransactionMode.java
@@ -109,7 +109,7 @@ public class DbTransactionMode {
 		if (this == object) {
 			return true;
 		}
-		if (!(object instanceof DbTransactionMode)) {
+		if (this.getClass() != object.getClass()) {
 			return false;
 		}
 		DbTransactionMode mode = (DbTransactionMode) object;

--- a/jodd-db/src/main/java/jodd/db/oom/DbEntityColumnDescriptor.java
+++ b/jodd-db/src/main/java/jodd/db/oom/DbEntityColumnDescriptor.java
@@ -129,7 +129,7 @@ public class DbEntityColumnDescriptor implements Comparable {
 		if (this == o) {
 			return true;
 		}
-		if (!(o instanceof DbEntityColumnDescriptor)) {
+		if (this.getClass() != o.getClass()) {
 			return false;
 		}
 		DbEntityColumnDescriptor that = (DbEntityColumnDescriptor) o;

--- a/jodd-jtx/src/main/java/jodd/jtx/JtxTransactionMode.java
+++ b/jodd-jtx/src/main/java/jodd/jtx/JtxTransactionMode.java
@@ -220,7 +220,7 @@ s	 */
 		if (this == object) {
 			return true;
 		}
-		if (!(object instanceof JtxTransactionMode)) {
+		if (this.getClass() != object.getClass()) {
 			return false;
 		}
 		JtxTransactionMode mode = (JtxTransactionMode) object;

--- a/jodd-proxetta/src/main/java/jodd/asm5/Type.java
+++ b/jodd-proxetta/src/main/java/jodd/asm5/Type.java
@@ -843,7 +843,7 @@ public class Type {
         if (this == o) {
             return true;
         }
-        if (!(o instanceof Type)) {
+        if (this.getClass() != o.getClass()) {
             return false;
         }
         Type t = (Type) o;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2162
- equals methods should be symmetric and work for subclasses
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid:S2162
Please let me know if you have any questions.
M-Ezzat