### PR TITLE
squid:S1444 - "public static" fields should be constant

### DIFF
--- a/jodd-core/src/main/java/jodd/core/JoddCore.java
+++ b/jodd-core/src/main/java/jodd/core/JoddCore.java
@@ -40,12 +40,12 @@ public class JoddCore {
 	/**
 	 * Default temp file prefix.
 	 */
-	public static String tempFilePrefix = "jodd-";
+	public static final String tempFilePrefix = "jodd-";
 
 	/**
 	 * Default file encoding (UTF8).
 	 */
-	public static String encoding = StringPool.UTF_8;
+	public static final String encoding = StringPool.UTF_8;
 
 	/**
 	 * Default IO buffer size (16 KB).
@@ -55,12 +55,12 @@ public class JoddCore {
 	/**
 	 * Default parameters used in {@link jodd.io.FileUtil} operations.
 	 */
-	public static FileUtilParams fileUtilParams = new FileUtilParams();
+	public static final FileUtilParams fileUtilParams = new FileUtilParams();
 
 	/**
 	 * Default class loader strategy.
 	 */
-	public static ClassLoaderStrategy classLoaderStrategy = new DefaultClassLoaderStrategy();
+	public static final ClassLoaderStrategy classLoaderStrategy = new DefaultClassLoaderStrategy();
 
 	// ---------------------------------------------------------------- module
 

--- a/jodd-core/src/main/java/jodd/datetime/JDateTimeDefault.java
+++ b/jodd-core/src/main/java/jodd/datetime/JDateTimeDefault.java
@@ -40,7 +40,7 @@ public class JDateTimeDefault {
 	/**
 	 * Default value for month fix.
 	 */
-	public static boolean monthFix = true;
+	public static final boolean monthFix = true;
 
 	/**
 	 * Default time zone. Set it to <code>null</code>
@@ -62,25 +62,25 @@ public class JDateTimeDefault {
 	/**
 	 * Default formatter.
 	 */
-	public static JdtFormatter formatter = new Iso8601JdtFormatter();
+	public static final JdtFormatter formatter = new Iso8601JdtFormatter();
 
 	/**
 	 * Default definition of first day of week.
 	 */
-	public static int firstDayOfWeek = JDateTime.MONDAY;
+	public static final int firstDayOfWeek = JDateTime.MONDAY;
 
 	/**
 	 * Default number of days first week of year must have.
 	 */
-	public static int mustHaveDayOfFirstWeek = 4;
+	public static final int mustHaveDayOfFirstWeek = 4;
 
 	/**
 	 * Default minimal number of days firs week of year must have.
 	 */
-	public static int minDaysInFirstWeek = 4;
+	public static final int minDaysInFirstWeek = 4;
 
 	/**
 	 * Default value for tracking DST.
 	 */
-	public static boolean trackDST = false;
+	public static final boolean trackDST = false;
 }

--- a/jodd-core/src/main/java/jodd/util/collection/IntArrayList.java
+++ b/jodd-core/src/main/java/jodd/util/collection/IntArrayList.java
@@ -34,7 +34,7 @@ public class IntArrayList {
 	private int[] array;
 	private int size;
 
-	public static int initialCapacity = 10;
+	public static final int initialCapacity = 10;
 
 	/**
 	 * Constructs an empty list with an initial capacity.

--- a/jodd-http/src/main/java/jodd/http/JoddHttp.java
+++ b/jodd-http/src/main/java/jodd/http/JoddHttp.java
@@ -38,33 +38,33 @@ public class JoddHttp {
 	/**
 	 * Default HTTP transport provider.
 	 */
-	public static HttpConnectionProvider httpConnectionProvider = new SocketHttpConnectionProvider();
+	public static final HttpConnectionProvider httpConnectionProvider = new SocketHttpConnectionProvider();
 
 	/**
 	 * Default HTTP query parameters encoding (UTF-8).
 	 */
-	public static String defaultQueryEncoding = StringPool.UTF_8;
+	public static final String defaultQueryEncoding = StringPool.UTF_8;
 
 	/**
 	 * Default form encoding (UTF-8).
 	 */
-	public static String defaultFormEncoding = StringPool.UTF_8;
+	public static final String defaultFormEncoding = StringPool.UTF_8;
 
 	/**
 	 * Default body media type (text/html).
 	 */
-	public static String defaultBodyMediaType = MimeTypes.MIME_TEXT_HTML;
+	public static final String defaultBodyMediaType = MimeTypes.MIME_TEXT_HTML;
 
 	/**
 	 * Default body encoding (UTF-8).
 	 */
-	public static String defaultBodyEncoding = StringPool.UTF_8;
+	public static final String defaultBodyEncoding = StringPool.UTF_8;
 
 	/**
 	 * CSV of default enabled secured protocols. By default the value is
 	 * read from system property <code>https.protocols</code>.
 	 */
-	public static String defaultSecureEnabledProtocols = System.getProperty("https.protocols");
+	public static final String defaultSecureEnabledProtocols = System.getProperty("https.protocols");
 
 	// ---------------------------------------------------------------- module
 

--- a/jodd-joy/src/main/java/jodd/joy/madvoc/result/VtorJsonResult.java
+++ b/jodd-joy/src/main/java/jodd/joy/madvoc/result/VtorJsonResult.java
@@ -59,7 +59,7 @@ public class VtorJsonResult extends BaseActionResult<String> {
 	 * In this case change response content type to "text/html". Or disable
 	 * iframe posting if possible.
 	 */
-	public static String jsonResponseContentType = MimeTypes.MIME_APPLICATION_JSON;
+	public static final String jsonResponseContentType = MimeTypes.MIME_APPLICATION_JSON;
 
 	public VtorJsonResult() {
 		super(NAME);

--- a/jodd-joy/src/main/java/jodd/joy/page/PageRequest.java
+++ b/jodd-joy/src/main/java/jodd/joy/page/PageRequest.java
@@ -33,11 +33,11 @@ public class PageRequest {
 	/**
 	 * Default page size.
 	 */
-	public static int defaultPageSize = 10;
+	public static final int defaultPageSize = 10;
 	/**
 	 * Default sort index.
 	 */
-	public static int defaultSortIndex = 0;
+	public static final int defaultSortIndex = 0;
 
 	protected int page = 1;
 	protected int size = defaultPageSize;

--- a/jodd-json/src/main/java/jodd/json/JoddJson.java
+++ b/jodd-json/src/main/java/jodd/json/JoddJson.java
@@ -44,7 +44,7 @@ public class JoddJson {
 	/**
 	 * Default JSON type serializers.
 	 */
-	public static TypeJsonSerializerMap defaultSerializers = new TypeJsonSerializerMap();
+	public static final TypeJsonSerializerMap defaultSerializers = new TypeJsonSerializerMap();
 
 	/**
 	 * Specifies if 'class' metadata is used. When set, class metadata
@@ -60,24 +60,24 @@ public class JoddJson {
 	 * If set to <code>true</code>, objects will be serialized
 	 * deep, so all collections and arrays will get serialized.
 	 */
-	public static boolean deepSerialization = false;
+	public static final boolean deepSerialization = false;
 
 	/**
 	 * Defines if parser will use extended paths information
 	 * and path matching.
 	 */
-	public static boolean useAltPathsByParser = false;
+	public static final boolean useAltPathsByParser = false;
 
 	/**
 	 * List of excluded types for serialization.
 	 */
-	public static Class[] excludedTypes = null;
+	public static final Class[] excludedTypes = null;
 
 	/**
 	 * List of excluded types names for serialization. Type name
 	 * can contain wildcards (<code>*</code> and <code>?</code>).
 	 */
-	public static String[] excludedTypeNames = null;
+	public static final String[] excludedTypeNames = null;
 
 	/**
 	 * When <code>true</code>, then search for first annotated
@@ -88,7 +88,7 @@ public class JoddJson {
 	/**
 	 * Default JSON annotation manager.
 	 */
-	public static JsonAnnotationManager annotationManager = new JsonAnnotationManager();
+	public static final JsonAnnotationManager annotationManager = new JsonAnnotationManager();
 
 	// ---------------------------------------------------------------- module
 

--- a/jodd-mail/src/main/java/jodd/mail/EmailAddress.java
+++ b/jodd-mail/src/main/java/jodd/mail/EmailAddress.java
@@ -61,7 +61,7 @@ public class EmailAddress {
 	 * and specifically only those with at least two levels ("example.com"), then
 	 * change this constant to <code>false</code>.
 	 */
-	public static boolean ALLOW_DOMAIN_LITERALS = false;
+	public static final boolean ALLOW_DOMAIN_LITERALS = false;
 
 	/**
 	 * This constant states that quoted identifiers are allowed
@@ -76,7 +76,7 @@ public class EmailAddress {
 	 * a raw address (<code>john.smith@somewhere.com</code> - no quotes or angle
 	 * brackets), then change this constant to <code>false</code>.
 	 */
-	public static boolean ALLOW_QUOTED_IDENTIFIERS = true;
+	public static final boolean ALLOW_QUOTED_IDENTIFIERS = true;
 
 	/**
 	 * This constant allows &quot;.&quot; to appear in atext (note: only atext which appears
@@ -95,7 +95,7 @@ public class EmailAddress {
 	 * If this boolean is set to false, the parser will act per 2822 and will require
 	 * the quotes; if set to true, it will allow the use of &quot;.&quot; without quotes.
 	 */
-	public static boolean ALLOW_DOT_IN_ATEXT = false;
+	public static final boolean ALLOW_DOT_IN_ATEXT = false;
 
 	/**
 	 * This controls the behavior of getInternetAddress and extractHeaderAddresses. If true,
@@ -118,7 +118,7 @@ public class EmailAddress {
 	 * the methods will favor the personal name to the left. If the methods need to use the
 	 * CFWS following the address, they will take the first comment token they find.
 	 */
-	public static boolean EXTRACT_CFWS_PERSONAL_NAMES = true;
+	public static final boolean EXTRACT_CFWS_PERSONAL_NAMES = true;
 
 	/**
 	 * This constant allows &quot;[&quot; or &quot;]&quot; to appear in atext.
@@ -135,7 +135,7 @@ public class EmailAddress {
 	 * Use at your own risk. There may be some issue with enabling this feature in conjunction
 	 * with ALLOW_DOMAIN_LITERALS.
 	 */
-	public static boolean ALLOW_SQUARE_BRACKETS_IN_ATEXT = false;
+	public static final boolean ALLOW_SQUARE_BRACKETS_IN_ATEXT = false;
 
 	/**
 	 * This constant allows &quot;)&quot; or &quot;(&quot; to appear in quoted versions of
@@ -143,7 +143,7 @@ public class EmailAddress {
 	 * The default (2822) behavior is to allow this, i.e. boolean true.
 	 * You can disallow it, but better to leave it true.
 	 */
-	public static boolean ALLOW_PARENS_IN_LOCALPART = true;
+	public static final boolean ALLOW_PARENS_IN_LOCALPART = true;
 
 	// ---------------------------------------------------------------- ctor
 

--- a/jodd-mail/src/main/java/jodd/mail/JoddMail.java
+++ b/jodd-mail/src/main/java/jodd/mail/JoddMail.java
@@ -35,7 +35,7 @@ public class JoddMail {
 	/**
 	 * Mail system properties for fine-tuning the java Mail behavior.
 	 */
-	public static MailSystem mailSystem = new MailSystem();
+	public static final MailSystem mailSystem = new MailSystem();
 
 	// ---------------------------------------------------------------- module
 

--- a/jodd-proxetta/src/main/java/jodd/proxetta/JoddProxetta.java
+++ b/jodd-proxetta/src/main/java/jodd/proxetta/JoddProxetta.java
@@ -35,57 +35,57 @@ public class JoddProxetta {
 	/**
 	 * {@link jodd.proxetta.ProxyAdvice#execute()}
 	 */
-	public static String executeMethodName = "execute";
+	public static final String executeMethodName = "execute";
 
 	/**
 	 * Proxy class name suffix.
 	 */
-	public static String proxyClassNameSuffix = "$$Proxetta";
+	public static final String proxyClassNameSuffix = "$$Proxetta";
 
 	/**
 	 * Invoke proxy class name suffix.
 	 */
-	public static String invokeProxyClassNameSuffix = "$$Clonetou";
+	public static final String invokeProxyClassNameSuffix = "$$Clonetou";
 
 	/**
 	 * Wrapper class name suffix.
 	 */
-	public static String wrapperClassNameSuffix = "$$Wraporetto";
+	public static final String wrapperClassNameSuffix = "$$Wraporetto";
 
 	/**
 	 * Prefix for advice method names.
 	 */
-	public static String methodPrefix = "$__";
+	public static final String methodPrefix = "$__";
 
 	/**
 	 * Divider for method names.
 	 */
-	public static String methodDivider = "$";
+	public static final String methodDivider = "$";
 
 	/**
 	 * Method name for advice 'clinit' methods.
 	 */
-	public static String clinitMethodName = "$clinit";
+	public static final String clinitMethodName = "$clinit";
 
 	/**
 	 * Method name for advice default constructor ('init') methods.
 	 */
-	public static String initMethodName = "$init";
+	public static final String initMethodName = "$init";
 
 	/**
 	 * Prefix for advice field names.
 	 */
-	public static String fieldPrefix = "$__";
+	public static final String fieldPrefix = "$__";
 
 	/**
 	 * Divider for field names.
 	 */
-	public static String fieldDivider = "$";
+	public static final String fieldDivider = "$";
 
 	/**
 	 * Wrapper target field name.
 	 */
-	public static String wrapperTargetFieldName = "_target";
+	public static final String wrapperTargetFieldName = "_target";
 
 	// ---------------------------------------------------------------- module
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1444 - "public static" fields should be constant
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid:S1444
Please let me know if you have any questions.
M-Ezzat