### PR TITLE
squid:S2272 - "Iterator.next()" methods should throw "NoSuchElementEx…

### DIFF
--- a/jodd-bean/src/test/java/jodd/typeconverter/TypeConverterTestHelper.java
+++ b/jodd-bean/src/test/java/jodd/typeconverter/TypeConverterTestHelper.java
@@ -31,6 +31,7 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashSet;
+import java.util.NoSuchElementException;
 
 public final class TypeConverterTestHelper {
 
@@ -120,6 +121,9 @@ public final class TypeConverterTestHelper {
 					}
 
 					public T next() {
+						if (!hasNext()) {
+							throw new NoSuchElementException();
+						}
 						T value = v[index.value];
 						index.value++;
 						return value;

--- a/jodd-core/src/main/java/jodd/cache/CacheValuesIterator.java
+++ b/jodd-core/src/main/java/jodd/cache/CacheValuesIterator.java
@@ -26,6 +26,7 @@
 package jodd.cache;
 
 import java.util.Iterator;
+import java.util.NoSuchElementException;
 
 /**
  * Values iterator for {@link jodd.cache.AbstractCacheMap}.
@@ -65,6 +66,9 @@ public class CacheValuesIterator<V> implements Iterator<V> {
 	 * Returns next non-expired element from the cache.
 	 */
 	public V next() {
+		if (!hasNext()) {
+			throw new NoSuchElementException();
+		}
 		V cachedObject = nextValue.cachedObject;
 		nextValue();
 		return cachedObject;

--- a/jodd-core/src/main/java/jodd/util/CollectionUtil.java
+++ b/jodd-core/src/main/java/jodd/util/CollectionUtil.java
@@ -30,6 +30,7 @@ import java.util.Collection;
 import java.util.Enumeration;
 import java.util.Iterator;
 import java.util.List;
+import java.util.NoSuchElementException;
 
 /**
  * Some collection utilities.
@@ -62,6 +63,9 @@ public class CollectionUtil {
 			}
 
 			public E next() {
+				if (!hasNext()) {
+					throw new NoSuchElementException();
+				}
 				return e.nextElement();
 			}
 

--- a/jodd-db/src/main/java/jodd/db/oom/DbListIterator.java
+++ b/jodd-db/src/main/java/jodd/db/oom/DbListIterator.java
@@ -29,6 +29,7 @@ import jodd.db.oom.mapper.ResultSetMapper;
 
 import java.util.Arrays;
 import java.util.Iterator;
+import java.util.NoSuchElementException;
 
 /**
  * Internal result set iterator.
@@ -86,6 +87,9 @@ class DbListIterator<T> implements Iterator<T> {
 	 * Returns next mapped object.
 	 */
 	public T next() {
+		if (!hasNext()) {
+			throw new NoSuchElementException();
+		}
 		if (hasNext == null) {
 			hasNext = Boolean.valueOf(moveToNext());
 		}

--- a/jodd-lagarto/src/main/java/jodd/jerry/Jerry.java
+++ b/jodd-lagarto/src/main/java/jodd/jerry/Jerry.java
@@ -42,6 +42,7 @@ import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.NoSuchElementException;
 import java.util.Set;
 
 /**
@@ -920,6 +921,9 @@ public class Jerry implements Iterable<Jerry> {
 			}
 
 			public Jerry next() {
+				if (!hasNext()) {
+					throw new NoSuchElementException();
+				}
 				Jerry nextJerry = new Jerry(jerry, jerry.get(index));
 				index++;
 				return nextJerry;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2272
- "Iterator.next()" methods should throw "NoSuchElementException"
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid:S2272
Please let me know if you have any questions.
M-Ezzat