### PR TITLE
squid:S1155, squid:S2786 - Collection.isEmpty() should be used to tes…

### DIFF
--- a/jodd-core/src/main/java/jodd/util/InExRules.java
+++ b/jodd-core/src/main/java/jodd/util/InExRules.java
@@ -104,7 +104,7 @@ public class InExRules<T, R> implements InExRuleMatcher<T, R> {
 		if (rules == null) {
 			return false;
 		}
-		return rules.size() > 0;
+		return !rules.isEmpty();
 	}
 
 	/**

--- a/jodd-db/src/test/java/jodd/db/oom/tst/Enumerator.java
+++ b/jodd-db/src/test/java/jodd/db/oom/tst/Enumerator.java
@@ -32,7 +32,7 @@ import jodd.db.oom.meta.DbTable;
 @DbTable
 public class Enumerator {
 
-	public static enum STATUS {
+	public enum STATUS {
 		ONE(1),
 		TWO(123),
 		THREE(222);

--- a/jodd-http/src/main/java/jodd/http/Buffer.java
+++ b/jodd-http/src/main/java/jodd/http/Buffer.java
@@ -96,7 +96,7 @@ public class Buffer {
 	 * Appends other buffer to this one.
 	 */
 	public Buffer append(Buffer buffer) {
-		if (buffer.list.size() == 0) {
+		if (buffer.list.isEmpty()) {
 			// nothing to append
 			return buffer;
 		}

--- a/jodd-http/src/main/java/jodd/http/ProxyInfo.java
+++ b/jodd-http/src/main/java/jodd/http/ProxyInfo.java
@@ -33,7 +33,7 @@ public class ProxyInfo {
 	/**
 	 * Proxy types.
 	 */
-	public static enum ProxyType {
+	public enum ProxyType {
 		NONE, HTTP, SOCKS4, SOCKS5
 	}
 

--- a/jodd-json/src/main/java/jodd/json/meta/JsonAnnotationManager.java
+++ b/jodd-json/src/main/java/jodd/json/meta/JsonAnnotationManager.java
@@ -269,13 +269,13 @@ public class JsonAnnotationManager {
 
 		String[] reals = null;
 
-		if (realNames.size() > 0) {
+		if (!realNames.isEmpty()) {
 			reals = realNames.toArray(new String[realNames.size()]);
 		}
 
 		String[] jsons = null;
-
-		if (jsonNames.size() > 0) {
+	
+		if (!jsonNames.isEmpty()) {
 			jsons = jsonNames.toArray(new String[jsonNames.size()]);
 		}
 

--- a/jodd-proxetta/src/test/java/jodd/proxetta/data/Hero.java
+++ b/jodd-proxetta/src/test/java/jodd/proxetta/data/Hero.java
@@ -33,7 +33,7 @@ package jodd.proxetta.data;
 		enemies = {2,1000})
 public class Hero {
 
-	public static enum POWER {
+	public enum POWER {
 		STRENGTH,
 		XRAY,
 		SPEED {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1155, squid:S2786 - Collection.isEmpty() should be used to test for emptiness, Nested "enum"s should not be declared static

You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid:S1155
https://dev.eclipse.org/sonar/coding_rules#q=squid:S2786

Please let me know if you have any questions.

M-Ezzat