### PR TITLE
squid:S2325 - "private" methods that dont access instance data should…

### DIFF
--- a/jodd-core/src/main/java/jodd/format/PrintfFormat.java
+++ b/jodd-core/src/main/java/jodd/format/PrintfFormat.java
@@ -360,7 +360,7 @@ public class PrintfFormat {
 		return new String(buffer);
 	}
 	
-	private String getAltPrefixFor(char fmt, String currentPrefix) {
+	private static String getAltPrefixFor(char fmt, String currentPrefix) {
 		switch(fmt) {
 			case 'x':
 				return "0x";

--- a/jodd-core/src/main/java/jodd/util/ResourceBundleMessageResolver.java
+++ b/jodd-core/src/main/java/jodd/util/ResourceBundleMessageResolver.java
@@ -1,3 +1,4 @@
+
 // Copyright (c) 2003-present, Jodd Team (http://jodd.org)
 // All rights reserved.
 //
@@ -58,7 +59,7 @@ public class ResourceBundleMessageResolver {
 	/**
 	 * Calculates indexedTextName (collection[*]) if applicable.
 	 */
-	private String calcIndexKey(String key) {
+	private static String calcIndexKey(String key) {
 		String indexedKey = null;
 		if (key.indexOf('[') != -1) {
 			int i = -1;

--- a/jodd-http/src/main/java/jodd/http/net/HTTPProxySocketFactory.java
+++ b/jodd-http/src/main/java/jodd/http/net/HTTPProxySocketFactory.java
@@ -150,7 +150,7 @@ public class HTTPProxySocketFactory extends SocketFactory {
 	/**
 	 * Closes socket silently.
 	 */
-	private void closeSocket(Socket socket) {
+	private static void closeSocket(Socket socket) {
 		try {
 			if (socket != null) {
 				socket.close();

--- a/jodd-http/src/main/java/jodd/http/net/Socks4ProxySocketFactory.java
+++ b/jodd-http/src/main/java/jodd/http/net/Socks4ProxySocketFactory.java
@@ -140,7 +140,7 @@ public class Socks4ProxySocketFactory extends SocketFactory {
 	/**
 	 * Closes socket silently.
 	 */
-	private void closeSocket(Socket socket) {
+	private static void closeSocket(Socket socket) {
 		try {
 			if (socket != null) {
 				socket.close();

--- a/jodd-http/src/main/java/jodd/http/net/Socks5ProxySocketFactory.java
+++ b/jodd-http/src/main/java/jodd/http/net/Socks5ProxySocketFactory.java
@@ -211,7 +211,7 @@ public class Socks5ProxySocketFactory extends SocketFactory {
 	/**
 	 * Closes socket silently.
 	 */
-	private void closeSocket(Socket socket) {
+	private static void closeSocket(Socket socket) {
 		try {
 			if (socket != null) {
 				socket.close();

--- a/jodd-lagarto/src/main/java/jodd/csselly/CSSellyLexer.java
+++ b/jodd-lagarto/src/main/java/jodd/csselly/CSSellyLexer.java
@@ -628,7 +628,7 @@ final class CSSellyLexer {
    *
    * @param   errorCode  the code of the errormessage to display
    */
-  private void zzScanError(int errorCode) {
+  private static void zzScanError(int errorCode) {
     String message;
     try {
       message = ZZ_ERROR_MSG[errorCode];

--- a/jodd-lagarto/src/main/java/jodd/lagarto/dom/HtmlCCommentExpressionMatcher.java
+++ b/jodd-lagarto/src/main/java/jodd/lagarto/dom/HtmlCCommentExpressionMatcher.java
@@ -123,7 +123,7 @@ public class HtmlCCommentExpressionMatcher {
 
 	// If in expression IE version is represented as a natural number
 	// we should compare only major number
-	private float versionToCompare(float ieVersion, float number) {
+	private static float versionToCompare(float ieVersion, float number) {
 		return (int) number == number ? (int) ieVersion : ieVersion;
 	}
 }

--- a/jodd-props/src/main/java/jodd/props/PropertiesToProps.java
+++ b/jodd-props/src/main/java/jodd/props/PropertiesToProps.java
@@ -70,7 +70,7 @@ class PropertiesToProps {
 		}
 	}
 
-	private BufferedWriter getBufferedWriter(final Writer writer) {
+	private static BufferedWriter getBufferedWriter(final Writer writer) {
 		final BufferedWriter bw;
 		if (writer instanceof BufferedWriter) {
 			bw = (BufferedWriter) writer;
@@ -103,14 +103,14 @@ class PropertiesToProps {
 		}
 	}
 
-	private void writeProfileProperty(final BufferedWriter bw, final String profileName,
+	private static void writeProfileProperty(final BufferedWriter bw, final String profileName,
 									  final String key, final String value)
 			throws IOException {
 		bw.write(key + '<' + profileName + '>' + '=' + value);
 		bw.newLine();
 	}
 
-	private void writeBaseProperty(final BufferedWriter bw, final String key, final String value)
+	private static void writeBaseProperty(final BufferedWriter bw, final String key, final String value)
 			throws IOException {
 		bw.write(key + '=' + value);
 		bw.newLine();

--- a/jodd-upload/src/main/java/jodd/upload/FileUploadHeader.java
+++ b/jodd-upload/src/main/java/jodd/upload/FileUploadHeader.java
@@ -82,7 +82,7 @@ public class FileUploadHeader {
 	/**
 	 * Gets value of data field or <code>null</code> if field not found.
 	 */
-	private String getDataFieldValue(String dataHeader, String fieldName) {
+	private static String getDataFieldValue(String dataHeader, String fieldName) {
 		String value = null;
 		String token = String.valueOf((new StringBuffer(String.valueOf(fieldName))).append('=').append('"'));
 		int pos = dataHeader.indexOf(token);
@@ -111,13 +111,13 @@ public class FileUploadHeader {
 		return dataHeader.substring(start);
 	}
 
-	private String getContentDisposition(String dataHeader) {
+	private static String getContentDisposition(String dataHeader) {
 		int start = dataHeader.indexOf(':') + 1;
 		int end = dataHeader.indexOf(';');
 		return dataHeader.substring(start, end);
 	}
 
-	private String getMimeType(String ContentType) {
+	private static String getMimeType(String ContentType) {
 		int pos = ContentType.indexOf('/');
 		if (pos == -1) {
 			return ContentType;
@@ -125,7 +125,7 @@ public class FileUploadHeader {
 		return ContentType.substring(1, pos);
 	}
 
-	private String getMimeSubtype(String ContentType) {
+	private static String getMimeSubtype(String ContentType) {
 		int start = ContentType.indexOf('/');
 		if (start == -1) {
 			return ContentType;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2325 - "private" methods that don't access instance data should be "static"

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S2325

Please let me know if you have any questions.

M-Ezzat