### PR TITLE
squid:S2097, squid:S1488 - "equals(Object obj)" should test argument …

### DIFF
--- a/jodd-core/src/main/java/jodd/util/collection/StringKeyedMapAdapter.java
+++ b/jodd-core/src/main/java/jodd/util/collection/StringKeyedMapAdapter.java
@@ -93,6 +93,14 @@ public abstract class StringKeyedMapAdapter extends AbstractMap<String, Object> 
 				entries.add(new Entry<String, Object>() {
 					@Override
 					public boolean equals(Object obj) {
+						if (obj == null) {
+							return false;
+						}
+
+						if (this.getClass() != obj.getClass()) {
+							return false;
+						}
+
 						Entry entry = (Entry) obj;
 						return ((key == null) ? (entry.getKey() == null) : key.equals(entry.getKey())) && ((value == null) ? (entry.getValue() == null) : value.equals(entry.getValue()));
 					}

--- a/jodd-proxetta/src/test/java/jodd/proxetta/InvReplTest.java
+++ b/jodd-proxetta/src/test/java/jodd/proxetta/InvReplTest.java
@@ -154,7 +154,7 @@ public class InvReplTest {
 
 
 	protected InvokeProxetta initProxetta() {
-		InvokeProxetta fp = InvokeProxetta.withAspects(
+		return InvokeProxetta.withAspects(
 				new InvokeAspect() {
 					@Override
 					public InvokeReplacer pointcut(InvokeInfo invokeInfo) {
@@ -202,6 +202,5 @@ public class InvReplTest {
 					}
 				}
 		);
-		return fp;
 	}
 }

--- a/jodd-proxetta/src/test/java/jodd/proxetta/data/DateDao2.java
+++ b/jodd-proxetta/src/test/java/jodd/proxetta/data/DateDao2.java
@@ -53,8 +53,7 @@ public class DateDao2 {
 		long end = start;
 
 		try {
-			Object result = currentTime0();
-			return result;
+			return currentTime0();
 		}
 		catch (Exception e) {
 			throw e;

--- a/jodd-proxetta/src/test/java/jodd/proxetta/data/PerformanceMeasureProxyAdvice.java
+++ b/jodd-proxetta/src/test/java/jodd/proxetta/data/PerformanceMeasureProxyAdvice.java
@@ -40,8 +40,7 @@ public class PerformanceMeasureProxyAdvice implements ProxyAdvice {
 		long end = start;
 
 		try {
-			Object result = ProxyTarget.invoke();
-			return result;
+			return ProxyTarget.invoke();
 		}
 		catch (Exception e) {
 			throw e;

--- a/jodd-proxetta/src/test/java/jodd/proxetta/petite/data/PetiteHelper.java
+++ b/jodd-proxetta/src/test/java/jodd/proxetta/petite/data/PetiteHelper.java
@@ -24,11 +24,10 @@ public class PetiteHelper {
 
         ProxyPointcut pointcut_logged = new MethodAnnotationPointcut(Logged.class);
         ProxyAspect aspect_logged = new ProxyAspect(LogProxyAdvice.class, pointcut_logged);
-
-        ProxyProxetta proxetta = ProxyProxetta.withAspects(aspect_logged);
+        
         //proxetta.setDebugFolder(SystemUtil.userHome() + "\\inka\\proxetta");
 
-        return proxetta;
+        return ProxyProxetta.withAspects(aspect_logged);
     }
 
 }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2097, squid:S1488 - "equals(Object obj)" should test argument type, Local Variables should not be declared and then immediately returned or thrown

You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid:S2097
https://dev.eclipse.org/sonar/coding_rules#q=squid:S1488

Please let me know if you have any questions.

M-Ezzat