### PR TITLE
squid:SwitchLastCaseIsDefaultCheck - switch statements should end wit…

### DIFF
--- a/jodd-core/src/main/java/jodd/format/PrintfFormat.java
+++ b/jodd-core/src/main/java/jodd/format/PrintfFormat.java
@@ -718,6 +718,8 @@ public class PrintfFormat {
 				return pad(s);
 			case 'p' :
 				return Integer.toString(System.identityHashCode(object));
+			default:
+				break;
 		}
 
 		// check for numeric type

--- a/jodd-core/src/main/java/jodd/io/findfile/FindFile.java
+++ b/jodd-core/src/main/java/jodd/io/findfile/FindFile.java
@@ -465,6 +465,8 @@ public class FindFile<T extends FindFile> {
 				break;
 			case NAME:
 				path = file.getName();
+			default:
+				break;
 		}
 
 		path = FileNameUtil.separatorsToUnix(path);

--- a/jodd-core/src/main/java/jodd/util/Base32.java
+++ b/jodd-core/src/main/java/jodd/util/Base32.java
@@ -109,6 +109,8 @@ public class Base32 {
 			case 3:
 			case 6:
 				throw new IllegalArgumentException(ERR_CANONICAL_LEN);
+			default:
+				break;
 		}
 
 		byte[] bytes = new byte[base32.length() * 5 / 8];

--- a/jodd-core/src/main/java/jodd/util/MurmurHash3.java
+++ b/jodd-core/src/main/java/jodd/util/MurmurHash3.java
@@ -157,6 +157,8 @@ public class MurmurHash3 {
 				k1 = Long.rotateLeft(k1, 31);
 				k1 *= c2;
 				h1 ^= k1;
+			default:
+				break;
 		}
 
 		//----------

--- a/jodd-db/src/main/java/jodd/db/jtx/JtxDbUtil.java
+++ b/jodd-db/src/main/java/jodd/db/jtx/JtxDbUtil.java
@@ -45,6 +45,7 @@ public class JtxDbUtil {
 			case ISOLATION_READ_UNCOMMITTED: isolation = DbTransactionMode.ISOLATION_READ_UNCOMMITTED; break;
 			case ISOLATION_REPEATABLE_READ: isolation = DbTransactionMode.ISOLATION_REPEATABLE_READ; break;
 			case ISOLATION_SERIALIZABLE: isolation = DbTransactionMode.ISOLATION_SERIALIZABLE; break;
+			default: break;
 		}
 		DbTransactionMode result = new DbTransactionMode();
 		result.setIsolation(isolation);

--- a/jodd-db/src/main/java/jodd/db/oom/sqlgen/chunks/ColumnsSelectChunk.java
+++ b/jodd-db/src/main/java/jodd/db/oom/sqlgen/chunks/ColumnsSelectChunk.java
@@ -285,6 +285,8 @@ public class ColumnsSelectChunk extends SqlChunk {
 					String code = templateData.registerColumnDataForColumnCode(tableName, column);
 					query.append(code);
 					break;
+				default:
+					break;
 			}
 		}
 	}

--- a/jodd-http/src/main/java/jodd/http/net/SocketHttpConnectionProvider.java
+++ b/jodd-http/src/main/java/jodd/http/net/SocketHttpConnectionProvider.java
@@ -174,6 +174,8 @@ public class SocketHttpConnectionProvider implements HttpConnectionProvider {
 				return new Socks4ProxySocketFactory(proxy);
 			case SOCKS5:
 				return new Socks5ProxySocketFactory(proxy);
+			default:
+				break;
 		}
 		return null;
 	}

--- a/jodd-json/src/main/java/jodd/json/JsonParser.java
+++ b/jodd-json/src/main/java/jodd/json/JsonParser.java
@@ -401,6 +401,8 @@ public class JsonParser extends JsonParserBase {
 					return value;
 				}
 				break;
+			default:
+				break;
 		}
 
 		if (looseMode) {

--- a/jodd-jtx/src/main/java/jodd/jtx/JtxTransactionManager.java
+++ b/jodd-jtx/src/main/java/jodd/jtx/JtxTransactionManager.java
@@ -283,6 +283,7 @@ public class JtxTransactionManager {
 			case PROPAGATION_REQUIRES_NEW: return propRequiresNew(currentTx, mode, scope);
 			case PROPAGATION_NOT_SUPPORTED: return propNotSupported(currentTx, mode, scope);
 			case PROPAGATION_NEVER: return propNever(currentTx, mode, scope);
+			default: break;
 		}
 		throw new JtxException("Invalid TX propagation value: " + mode.getPropagationBehavior().value());
 	}

--- a/jodd-lagarto/src/main/java/jodd/csselly/CssSelector.java
+++ b/jodd-lagarto/src/main/java/jodd/csselly/CssSelector.java
@@ -200,6 +200,8 @@ public class CssSelector implements NodeFilter {
 					out.append(':').append(pfns.getPseudoFunction().getPseudoFunctionName()).append('(');
 					out.append(pfns.getExpression()).append(')');
 					break;
+				default:
+					break;
 			}
 		}
 
@@ -248,6 +250,8 @@ public class CssSelector implements NodeFilter {
 					if (!((PseudoFunctionSelector) selector).accept(node)) {
 						return false;
 					}
+					break;
+				default:
 					break;
 			}
 		}

--- a/jodd-lagarto/src/main/java/jodd/lagarto/LagartoParser.java
+++ b/jodd-lagarto/src/main/java/jodd/lagarto/LagartoParser.java
@@ -2616,6 +2616,8 @@ public class LagartoParser extends Scanner {
 								return;
 							}
 							break;
+						default:
+							break;
 					}
 
 					errorInvalidToken();
@@ -2705,6 +2707,7 @@ public class LagartoParser extends Scanner {
 							case 0: version = value; break;
 							case 1: encoding = value; break;
 							case 2: standalone = value; break;
+							default: break;
 						}
 
 						xmlAttrCount++;

--- a/jodd-lagarto/src/main/java/jodd/lagarto/dom/LagartoDOMBuilderTagVisitor.java
+++ b/jodd-lagarto/src/main/java/jodd/lagarto/dom/LagartoDOMBuilderTagVisitor.java
@@ -261,6 +261,8 @@ public class LagartoDOMBuilderTagVisitor implements TagVisitor {
 				node = createElementNode(tag);
 				parentNode.addChild(node);
 				break;
+			default:
+				break;
 		}
 	}
 

--- a/jodd-lagarto/src/main/java/jodd/lagarto/dom/LagartoHtmlRendererNodeVisitor.java
+++ b/jodd-lagarto/src/main/java/jodd/lagarto/dom/LagartoHtmlRendererNodeVisitor.java
@@ -167,6 +167,7 @@ public class LagartoHtmlRendererNodeVisitor implements NodeVisitor {
 			case RAW: return node.getNodeRawName();
 			case LOWERCASE: return node.getNodeRawName().toLowerCase();
 			case UPPERCASE: return node.getNodeRawName().toUpperCase();
+			default: break;
 		}
 		return null;
 	}
@@ -180,6 +181,7 @@ public class LagartoHtmlRendererNodeVisitor implements NodeVisitor {
 			case RAW: return attribute.getRawName();
 			case LOWERCASE: return attribute.getRawName().toLowerCase();
 			case UPPERCASE: return attribute.getRawName().toUpperCase();
+			default: break;
 		}
 		return null;
 	}

--- a/jodd-lagarto/src/main/java/jodd/lagarto/dom/NodeSelector.java
+++ b/jodd-lagarto/src/main/java/jodd/lagarto/dom/NodeSelector.java
@@ -221,6 +221,8 @@ public class NodeSelector {
 					selectAndAdd(node, cssSelector, result);
 				}
 				break;
+			default:
+				break;
 		}	}
 
 	/**

--- a/jodd-log/src/main/java/jodd/log/impl/JCLLogger.java
+++ b/jodd-log/src/main/java/jodd/log/impl/JCLLogger.java
@@ -63,6 +63,7 @@ public class JCLLogger implements Logger {
 			case INFO: logger.info(message); break;
 			case WARN: logger.warn(message); break;
 			case ERROR: logger.error(message); break;
+			default: break;
 		}
 	}
 

--- a/jodd-log/src/main/java/jodd/log/impl/Slf4jLogger.java
+++ b/jodd-log/src/main/java/jodd/log/impl/Slf4jLogger.java
@@ -61,6 +61,7 @@ public class Slf4jLogger implements Logger {
 			case INFO: logger.info(message); break;
 			case WARN: logger.warn(message); break;
 			case ERROR: logger.error(message); break;
+			default: break;
 		}
 	}
 

--- a/jodd-petite/src/main/java/jodd/petite/InjectionPointFactory.java
+++ b/jodd-petite/src/main/java/jodd/petite/InjectionPointFactory.java
@@ -108,6 +108,7 @@ public class InjectionPointFactory {
 				case NAME:				references[i] = propertyDescriptor.getName(); break;
 				case TYPE_SHORT_NAME:	references[i] = StringUtil.uncapitalize(propertyDescriptor.getType().getSimpleName()); break;
 				case TYPE_FULL_NAME:	references[i] = propertyDescriptor.getType().getName(); break;
+				default: break;
 			}
 		}
 		return references;
@@ -135,6 +136,7 @@ public class InjectionPointFactory {
 					case NAME:				ref[i] = methodParameters != null ? methodParameters[j].getName() : null; break;
 					case TYPE_SHORT_NAME:	ref[i] = StringUtil.uncapitalize(paramTypes[j].getSimpleName()); break;
 					case TYPE_FULL_NAME:	ref[i] = paramTypes[j].getName(); break;
+					default: break;
 				}
 			}
 		}

--- a/jodd-proxetta/src/main/java/jodd/asm5/ClassReader.java
+++ b/jodd-proxetta/src/main/java/jodd/asm5/ClassReader.java
@@ -1959,6 +1959,8 @@ public class ClassReader {
             default:
                 v = readAnnotationValues(v - 3, buf, false, av.visitArray(name));
             }
+            default:
+                break;
         }
         return v;
     }
@@ -2436,6 +2438,8 @@ public class ClassReader {
                 cc = (char) ((cc << 6) | (c & 0x3F));
                 st = 1;
                 break;
+                default:
+                    break;
             }
         }
         return new String(buf, 0, strLen);

--- a/jodd-proxetta/src/main/java/jodd/asm5/MethodWriter.java
+++ b/jodd-proxetta/src/main/java/jodd/asm5/MethodWriter.java
@@ -700,6 +700,8 @@ class MethodWriter extends MethodVisitor {
                 }
                 writeFrameType(stack[0]);
                 break;
+                default:
+                    break;
             }
 
             previousFrameOffset = code.length;
@@ -1889,6 +1891,8 @@ class MethodWriter extends MethodVisitor {
             case 3:
                 type = APPEND_FRAME;
                 break;
+                default:
+                    break;
             }
         } else if (clocalsSize == localsSize && cstackSize == 1) {
             type = delta < 63 ? SAME_LOCALS_1_STACK_ITEM_FRAME

--- a/jodd-proxetta/src/main/java/jodd/asm5/signature/SignatureReader.java
+++ b/jodd-proxetta/src/main/java/jodd/asm5/signature/SignatureReader.java
@@ -221,6 +221,8 @@ public class SignatureReader {
                             break;
                         }
                     }
+                    default:
+                        break;
                 }
             }
         }

--- a/jodd-proxetta/src/main/java/jodd/proxetta/asm/ProxettaAsmUtil.java
+++ b/jodd-proxetta/src/main/java/jodd/proxetta/asm/ProxettaAsmUtil.java
@@ -503,7 +503,8 @@ public class ProxettaAsmUtil {
 			case 'D':
 				AsmUtil.valueOfDouble(mv);
 				break;
-
+			default:
+				break;
 		}
 	}
 

--- a/jodd-servlet/src/main/java/jodd/servlet/ServletUtil.java
+++ b/jodd-servlet/src/main/java/jodd/servlet/ServletUtil.java
@@ -724,6 +724,8 @@ public class ServletUtil {
 						}
 						result.append("\nPAGE\n----\n");
 						enumeration = pageContext.getAttributeNamesInScope(PageContext.PAGE_SCOPE);
+				default:
+					break;
 			}
 			while (enumeration.hasMoreElements()) {
 				String name = (String) enumeration.nextElement();
@@ -733,6 +735,7 @@ public class ServletUtil {
 					case 1: value = session.getAttribute(name); break;
 					case 2: value = context.getAttribute(name); break;
 					case 3: value = pageContext.getAttribute(name); break;
+					default: break;
 				}
 				result.append(name).append('=');
 				if (value == null) {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:SwitchLastCaseIsDefaultCheck - "switch" statements should end with a "default" clause

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:SwitchLastCaseIsDefaultCheck

Please let me know if you have any questions.

M-Ezzat