### PR TITLE
Ignoring silently 'null' arguments passed to 'basicAuthentication' method

### DIFF
--- a/jodd-http/src/main/java/jodd/http/HttpRequest.java
+++ b/jodd-http/src/main/java/jodd/http/HttpRequest.java
@@ -528,11 +528,14 @@ public class HttpRequest extends HttpBase<HttpRequest> {
 	 * Enables basic authentication by adding required header.
 	 */
 	public HttpRequest basicAuthentication(String username, String password) {
-		String data = username.concat(StringPool.COLON).concat(password);
 
-		String base64 = Base64.encodeToString(data);
+		if (username != null && password != null) {
+			String data = username.concat(StringPool.COLON).concat(password);
 
-		header("Authorization", "Basic " + base64, true);
+			String base64 = Base64.encodeToString(data);
+
+			header("Authorization", "Basic " + base64, true);
+		}
 
 		return this;
 	}

--- a/jodd-http/src/test/java/jodd/http/HttpRequestTest.java
+++ b/jodd-http/src/test/java/jodd/http/HttpRequestTest.java
@@ -36,9 +36,7 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.junit.Assert.*;
 
 public class HttpRequestTest {
 
@@ -291,4 +289,24 @@ public class HttpRequestTest {
 		assertEquals("http://foo.com", httpRequest.hostUrl());
 	}
 
+	@Test
+	public void testBasicAuthorizationCanBeSetToNullAndIsIgnoredSilently() {
+		HttpRequest httpRequest = new HttpRequest();
+		String[][] input = new String[][]{
+				{"non-null", null},
+				{null, "non-null"},
+				{null, null},
+		};
+
+		try {
+
+			for(String[] pair :input) {
+				httpRequest.basicAuthentication(pair[0], pair[1]);
+				assertNull(httpRequest.headers.get("Authorization"));
+			}
+
+		} catch (RuntimeException e) {
+			fail("No exception should be thrown for null authorization basic header args!");
+		}
+	}
 }


### PR DESCRIPTION
Relates to [this](https://github.com/oblac/jodd/issues/319) issue.