### PR TITLE
Updating BooleanConverter to treat empty string as false boolean value

### DIFF
--- a/jodd-bean/src/main/java/jodd/typeconverter/impl/BooleanConverter.java
+++ b/jodd-bean/src/main/java/jodd/typeconverter/impl/BooleanConverter.java
@@ -52,7 +52,12 @@ public class BooleanConverter implements TypeConverter<Boolean> {
 			return (Boolean) value;
 		}
 
-		String stringValue = value.toString().trim().toLowerCase();
+		String stringValue = value.toString();
+		if (stringValue.isEmpty()) {
+			return Boolean.FALSE;
+		}
+
+		stringValue = stringValue.trim().toLowerCase();
 		if (stringValue.equals(YES) ||
 				stringValue.equals(Y) ||
 				stringValue.equals(TRUE) ||

--- a/jodd-bean/src/test/java/jodd/typeconverter/BooleanConverterTest.java
+++ b/jodd-bean/src/test/java/jodd/typeconverter/BooleanConverterTest.java
@@ -26,6 +26,7 @@
 package jodd.typeconverter;
 
 import jodd.typeconverter.impl.BooleanConverter;
+import org.junit.Before;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
@@ -33,10 +34,16 @@ import static org.junit.Assert.assertNull;
 
 public class BooleanConverterTest {
 
+	private static BooleanConverter booleanConverter;
+
+	@Before
+	public void setUp(){
+		booleanConverter = new BooleanConverter();
+	}
+
+
 	@Test
 	public void testConversion() {
-		BooleanConverter booleanConverter = new BooleanConverter();
-
 		assertNull(booleanConverter.convert(null));
 
 		assertEquals(Boolean.TRUE, booleanConverter.convert(Boolean.TRUE));
@@ -58,6 +65,18 @@ public class BooleanConverterTest {
 		assertEquals(Boolean.FALSE, booleanConverter.convert("off"));
 		assertEquals(Boolean.FALSE, booleanConverter.convert("OFF"));
 		assertEquals(Boolean.FALSE, booleanConverter.convert("0"));
+		assertEquals(Boolean.FALSE, booleanConverter.convert(""));
 	}
+
+	@Test(expected = TypeConversionException.class)
+	public void testConversionWithBlankInput() {
+		booleanConverter.convert("    ");
+	}
+
+	@Test(expected = TypeConversionException.class)
+	public void testConversionWithUnrecognizedInput() {
+		booleanConverter.convert("asd#%^&(412");
+	}
+
 }
 


### PR DESCRIPTION
Updating BooleanConverter to treat empty string as false boolean value
and adding some tests checking only-white-space and ‘invalid’ input.