### PR TITLE
Update name of mail module in README to "jodd-mail"

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Some tools and utility modules are:
 + `jodd-core` contains many utilities, including `JDateTime`.
 + `jodd-bean`, our infamous `BeanUtil`, type inspectors and converters.
 + `jodd-props` is the super-replacement for Java `Properties`.
-+ `jodd-email` for easier email sending.
++ `jodd-mail` for easier email sending.
 + `jodd-upload`, handles HTTP uploads.
 + `jodd-servlet` with many servlet utilities, including nice tag library.
 + `jodd-http`, tiny HTTP client.


### PR DESCRIPTION
The module for email sending was listed as `jodd-email` in the readme. This did not match the name of the module directory and the artifact in the Maven Central Repository, which are both `jodd-mail`. I have updated the readme to list the module as `jodd-mail`. All the other modules listed in the readme match the directory name and artifact in Maven Central. There are no other references to `jodd-email` in the project.

