### PR TITLE
add .after, .unwrap, .replaceWith-operations to jerry

### DIFF
--- a/jodd-lagarto/src/main/java/jodd/jerry/Jerry.java
+++ b/jodd-lagarto/src/main/java/jodd/jerry/Jerry.java
@@ -971,6 +971,25 @@ public class Jerry implements Iterable<Jerry> {
 	}
 
 	/**
+	 * Inserts content, specified by the parameter, after each
+	 * element in the set of matched elements.
+	 */
+	public Jerry after(String html) {
+		if (html == null) {
+			html = StringPool.EMPTY;
+		}
+		final Document doc = builder.parse(html);
+		if (nodes.length == 0) {
+			return this;
+		}
+		for (Node node : nodes) {
+			Document workingDoc = doc.clone();
+			node.insertAfter(workingDoc.getChildNodes(), node);
+		}
+		return this;
+	}
+
+	/**
 	 * Removes the set of matched elements from the DOM.
 	 */
 	public Jerry remove() {

--- a/jodd-lagarto/src/main/java/jodd/jerry/Jerry.java
+++ b/jodd-lagarto/src/main/java/jodd/jerry/Jerry.java
@@ -989,10 +989,9 @@ public class Jerry implements Iterable<Jerry> {
 		return this;
 	}
 
-        /**
-	 * Remove the parents of the set of matched elements from the DOM, leaving 
-	 * the matched elements (and siblings, if any) in their place. 
-	 * Returns the set of elements that was removed.
+	/**
+	 * Replace each element in the set of matched elements with the provided 
+	 * new content and return the set of elements that was removed.
 	 */
 	public Jerry replaceWith(String html) {
  		if (html == null) {
@@ -1094,7 +1093,7 @@ public class Jerry implements Iterable<Jerry> {
 
 	/**
 	 * Remove the parents of the set of matched elements from the DOM, leaving 
-	* the matched elements (and siblings, if any) in their place. 
+	 * the matched elements (and siblings, if any) in their place. 
 	 */
 	public Jerry unwrap() {
 		if (nodes.length == 0) {

--- a/jodd-lagarto/src/main/java/jodd/jerry/Jerry.java
+++ b/jodd-lagarto/src/main/java/jodd/jerry/Jerry.java
@@ -989,6 +989,37 @@ public class Jerry implements Iterable<Jerry> {
 		return this;
 	}
 
+        /**
+	 * Remove the parents of the set of matched elements from the DOM, leaving 
+	 * the matched elements (and siblings, if any) in their place. 
+	 * Returns the set of elements that was removed.
+	 */
+	public Jerry replaceWith(String html) {
+ 		if (html == null) {
+			html = StringPool.EMPTY;
+		}
+		final Document doc = builder.parse(html);
+
+		if (nodes.length == 0) {
+			return this;
+		}
+		for (Node node : nodes) {
+			Node parent = node.getParentNode();
+			// if a node already is the root element, don't unwrap
+			if (parent == null) {
+				continue;
+			}
+
+			// replace, if possible
+			Document workingDoc = doc.clone();
+			int index = node.getSiblingIndex();
+			parent.insertChild(workingDoc.getFirstChild(), index);
+			node.detachFromParent();
+		}
+
+		return this;
+	}
+
 	/**
 	 * Removes the set of matched elements from the DOM.
 	 */
@@ -1056,6 +1087,36 @@ public class Jerry implements Iterable<Jerry> {
 			int index = node.getSiblingIndex();
 			inmostNode.addChild(node);
 			parent.insertChild(workingDoc.getFirstChild(), index);
+		}
+
+		return this;
+	}
+
+	/**
+	 * Remove the parents of the set of matched elements from the DOM, leaving 
+	* the matched elements (and siblings, if any) in their place. 
+	 */
+	public Jerry unwrap() {
+		if (nodes.length == 0) {
+			return this;
+		}
+		for (Node node : nodes) {
+			Node parent = node.getParentNode();
+			// if a node already is the root element, don't unwrap
+			if (parent == null) {
+				continue;
+			}
+
+			// replace, if possible
+			Node grandparent = parent.getParentNode();
+			if (grandparent == null) {
+				continue;
+			}
+
+			Node[] siblings = parent.getChildElements();
+			int index = parent.getSiblingIndex();
+			grandparent.insertChild(siblings, index);
+			parent.detachFromParent();
 		}
 
 		return this;

--- a/jodd-lagarto/src/test/java/jodd/jerry/JerryTest.java
+++ b/jodd-lagarto/src/test/java/jodd/jerry/JerryTest.java
@@ -472,6 +472,17 @@ public class JerryTest {
 	}
 
 	@Test
+	public void testAfter() {
+		String html = readFile("after.html");
+		String htmlOK = readFile("after-ok.html");
+
+		Jerry doc = jerry(html);
+		doc.$("p").after("<b>what is the question?</b>");
+
+		assertEquals(htmlOK, actualHtml(doc));
+	}
+
+	@Test
 	public void testIs() {
 		String html = readFile("is.html");
 		String htmlOK = readFile("is-ok.html");

--- a/jodd-lagarto/src/test/java/jodd/jerry/JerryTest.java
+++ b/jodd-lagarto/src/test/java/jodd/jerry/JerryTest.java
@@ -490,7 +490,6 @@ public class JerryTest {
 		Jerry doc = jerry(html);
 		doc.$("div.second").replaceWith("<h2>New heading</h2>");
 
-		String h = actualHtml(doc);
 		assertEquals(htmlOK, actualHtml(doc));
 	}
 
@@ -502,7 +501,6 @@ public class JerryTest {
 		Jerry doc = jerry(html);
 		doc.$("p").unwrap();
 
-		String h = actualHtml(doc);
 		assertEquals(htmlOK, actualHtml(doc));
 	}
 

--- a/jodd-lagarto/src/test/java/jodd/jerry/JerryTest.java
+++ b/jodd-lagarto/src/test/java/jodd/jerry/JerryTest.java
@@ -483,6 +483,30 @@ public class JerryTest {
 	}
 
 	@Test
+	public void testReplaceWith() {
+		String html = readFile("replaceWith.html");
+		String htmlOK = readFile("replaceWith-ok.html");
+
+		Jerry doc = jerry(html);
+		doc.$("div.second").replaceWith("<h2>New heading</h2>");
+
+		String h = actualHtml(doc);
+		assertEquals(htmlOK, actualHtml(doc));
+	}
+
+	@Test
+	public void testUnwrap() {
+		String html = readFile("unwrap.html");
+		String htmlOK = readFile("unwrap-ok.html");
+
+		Jerry doc = jerry(html);
+		doc.$("p").unwrap();
+
+		String h = actualHtml(doc);
+		assertEquals(htmlOK, actualHtml(doc));
+	}
+
+	@Test
 	public void testIs() {
 		String html = readFile("is.html");
 		String htmlOK = readFile("is-ok.html");

--- a/jodd-lagarto/src/test/resources/jodd/jerry/test/after-ok.html
+++ b/jodd-lagarto/src/test/resources/jodd/jerry/test/after-ok.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <style>p { background:yellow; }</style>
+  <script src="http://code.jquery.com/jquery-latest.js"></script>
+</head>
+<body>
+  <p>The question is... </p><b>what is the question?</b>
+<script>$("p").after("<b>what is the question?</b>");</script>
+
+</body>
+</html>

--- a/jodd-lagarto/src/test/resources/jodd/jerry/test/after.html
+++ b/jodd-lagarto/src/test/resources/jodd/jerry/test/after.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <style>p { background:yellow; }</style>
+  <script src="http://code.jquery.com/jquery-latest.js"></script>
+</head>
+<body>
+  <p>The question is... </p>
+<script>$("p").after("<b>what is the question?</b>");</script>
+
+</body>
+</html>

--- a/jodd-lagarto/src/test/resources/jodd/jerry/test/replaceWith-ok.html
+++ b/jodd-lagarto/src/test/resources/jodd/jerry/test/replaceWith-ok.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <script src="http://code.jquery.com/jquery-latest.js"></script>
+</head>
+<body>
+<div class="container">
+  <div class="inner first">Hello</div>
+  <h2>New heading</h2>
+  <div class="inner third">Goodbye</div>
+</div>
+<script>$("div.second").replaceWith("<h2>New heading</h2>");</script>
+
+</body>
+</html>

--- a/jodd-lagarto/src/test/resources/jodd/jerry/test/replaceWith.html
+++ b/jodd-lagarto/src/test/resources/jodd/jerry/test/replaceWith.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <script src="http://code.jquery.com/jquery-latest.js"></script>
+</head>
+<body>
+<div class="container">
+  <div class="inner first">Hello</div>
+  <div class="inner second">And</div>
+  <div class="inner third">Goodbye</div>
+</div>
+<script>$("div.second").replaceWith("<h2>New heading</h2>");</script>
+
+</body>
+</html>

--- a/jodd-lagarto/src/test/resources/jodd/jerry/test/unwrap-ok.html
+++ b/jodd-lagarto/src/test/resources/jodd/jerry/test/unwrap-ok.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <style>div { background:yellow; }</style>
+  <script src="http://code.jquery.com/jquery-latest.js"></script>
+</head>
+<body>
+  <p>Free me...</p><span>...and me</span>
+  <p>Me too!</p>
+<script>$("p").unwrap();</script>
+
+</body>
+</html>

--- a/jodd-lagarto/src/test/resources/jodd/jerry/test/unwrap.html
+++ b/jodd-lagarto/src/test/resources/jodd/jerry/test/unwrap.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <style>div { background:yellow; }</style>
+  <script src="http://code.jquery.com/jquery-latest.js"></script>
+</head>
+<body>
+  <div><p>Free me...</p><span>...and me</span></div>
+  <div><p>Me too!</p></div>
+<script>$("p").unwrap();</script>
+
+</body>
+</html>


### PR DESCRIPTION
Jerry supports the .before()-operation, but no .after(). Since I love using jerry in one of my projects and don't want to apply a workaround, I added the .after()-operation to jerry.