### PR TITLE
CommandLine Linux fix

### DIFF
--- a/jodd-core/src/main/java/jodd/util/CommandLine.java
+++ b/jodd-core/src/main/java/jodd/util/CommandLine.java
@@ -25,9 +25,13 @@
 
 package jodd.util;
 
+import java.io.BufferedReader;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileReader;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -38,6 +42,7 @@ import java.util.Map;
 import jodd.io.FileNameUtil;
 import jodd.io.FileUtil;
 import jodd.io.StreamGobbler;
+import jodd.io.StreamUtil;
 
 import static jodd.util.RuntimeUtil.ERROR_PREFIX;
 import static jodd.util.RuntimeUtil.OUTPUT_PREFIX;
@@ -182,8 +187,13 @@ public class CommandLine {
 			}
 		}
 		else if (SystemUtil.isHostAix() || SystemUtil.isHostLinux() || SystemUtil.isHostSolaris() || SystemUtil.isHostUnix()) {
-			newCommand.add("sh");
-			newCommand.add("-c");
+			String shebang = getShebang(commandFile);
+
+			newCommand.add(shebang);
+
+			if (shebang.equals("sh")) {
+				newCommand.add("-c");
+			}
 		}
 		else if (SystemUtil.isHostWindows()) {
 			newCommand.add("cmd");
@@ -193,6 +203,29 @@ public class CommandLine {
 		newCommand.add(command);
 
 		return newCommand;
+	}
+
+	protected String getShebang(File commandFile) {
+		String shebang;
+
+		if (commandFile.exists() && !commandFile.isDirectory() && commandFile.length() > 0) {
+
+			BufferedReader reader = null;
+
+			try {
+				reader = new BufferedReader(new FileReader(commandFile));
+				shebang = reader.readLine();
+				shebang = shebang.substring(shebang.indexOf('/'));
+			}
+			catch (Exception e) {
+				shebang = "sh";
+			}
+			finally {
+				StreamUtil.close(reader);
+			}
+		}
+
+		return shebang;
 	}
 
 	protected boolean isSH(String command) {


### PR DESCRIPTION
Hi Igor,

This fix handles the Linux related problem if there's no **sh** shell. Now it extracts the shell from the shebang from the first row and uses it as executor.

Regards,
Vilmos