### PR TITLE
Removed MaxPermSize option for tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -333,7 +333,6 @@ configure(javaModules()) {
 			 	'-Djacoco=true',
 			 	'-Xms128m',
 			 	'-Xmx512m',
-			 	'-XX:MaxPermSize=128m',
 			 	'-Duser.timezone=GMT'
 		}
 	}


### PR DESCRIPTION
MaxPermSize has been removed as of Java 8. Specifying the parameter yields a lot of warning during the test run