### PR TITLE
Improve StringUtil#replace throughput

### DIFF
--- a/jodd-core/src/main/java/jodd/util/StringUtil.java
+++ b/jodd-core/src/main/java/jodd/util/StringUtil.java
@@ -59,12 +59,12 @@ public class StringUtil {
 		int length = s.length();
 		StringBuilder sb = new StringBuilder(length + with.length());
 		do {
-			sb.append(s.substring(c, i));
+			sb.append(s, c, i);
 			sb.append(with);
 			c = i + sub.length();
 		} while ((i = s.indexOf(sub, c)) != -1);
 		if (c < length) {
-			sb.append(s.substring(c, length));
+			sb.append(s, c, length);
 		}
 		return sb.toString();
 	}


### PR DESCRIPTION
Motivation:

StringUtil#replace uses substring to append a String region into a
StringBuilder. This causes useless copies, as StringBuilder#append
can take start and end indexes.

Modification:

Use proper StringBuilder#append
[overload](https://docs.oracle.com/javase/8/docs/api/java/lang/StringBui
lder.html#append-java.lang.CharSequence-int-int-).

Result:

Better throughput. See https://github.com/apache/commons-lang/pull/300
for impact of similar change on commons-lang3.