### PR TITLE
fix bug in SimpleLogger.isEnabled

### DIFF
--- a/jodd-log/src/main/java/jodd/log/impl/SimpleLogger.java
+++ b/jodd-log/src/main/java/jodd/log/impl/SimpleLogger.java
@@ -52,7 +52,7 @@ public class SimpleLogger implements Logger {
 
 	@Override
 	public boolean isEnabled(Level level) {
-		return level.isEnabledFor(level);
+		return level.isEnabledFor(this.level);
 	}
 
 	@Override


### PR DESCRIPTION
Simple logger ignores its set level since its being hidden by parameter