### PR TITLE
enhancement StreamUtil and bigger refactoring StreamUtilTests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -69,8 +69,9 @@ ext {
 //		asm:			'org.ow2.asm:asm:4.1',
 //		junit: 			'junit:junit:4.12',
 
-		junit5:			'org.junit.jupiter:junit-jupiter-engine:5.0.0',
-		junit5_console: 'org.junit.platform:junit-platform-console:1.0.0',
+		junit5:			'org.junit.jupiter:junit-jupiter-engine:5.0.1',
+		junit5_params:	'org.junit.jupiter:junit-jupiter-params:5.0.1',
+		junit5_console: 'org.junit.platform:junit-platform-console:1.0.1',
 		hamcrest:       'org.hamcrest:hamcrest-core:1.3',
 		mockito:		'org.mockito:mockito-core:2.10.0',
 		hsqldb:			'org.hsqldb:hsqldb:2.2.9',

--- a/jodd-core/build.gradle
+++ b/jodd-core/build.gradle
@@ -4,6 +4,7 @@ ext.moduleDescription = 'Jodd Core tools and huge number of utilities.'
 
 dependencies {
 	testCompile lib.junit5
+	testCompile lib.junit5_params
 	testCompile 'org.webjars:jquery:2.1.1'
 	testCompile 'org.apache.commons:commons-lang3:3.6'
 }

--- a/jodd-core/src/main/java/jodd/io/StreamUtil.java
+++ b/jodd-core/src/main/java/jodd/io/StreamUtil.java
@@ -117,13 +117,17 @@ public class StreamUtil {
 
 
 	/**
-	 * Copies input stream to writer using buffer.
+	 * Copies input stream to writer using buffer - using jodds default encoding.
+     *
+     * @see JoddCore#encoding
 	 */
 	public static void copy(InputStream input, Writer output) throws IOException {
 		copy(input, output, JoddCore.encoding);
 	}
 	/**
-	 * Copies specified number of bytes from input stream to writer using buffer.
+	 * Copies specified number of bytes from input stream to writer using buffer - using jodds default encoding.
+     *
+     * @see JoddCore#encoding
 	 */
 	public static void copy(InputStream input, Writer output, int byteCount) throws IOException {
 		copy(input, output, JoddCore.encoding, byteCount);
@@ -184,13 +188,17 @@ public class StreamUtil {
 
 
 	/**
-	 * Copies reader to output stream using buffer.
+	 * Copies reader to output stream using buffer - using jodd default encoding.
+	 *
+	 * @see JoddCore#encoding
 	 */
 	public static void copy(Reader input, OutputStream output) throws IOException {
 		copy(input, output, JoddCore.encoding);
 	}
 	/**
-	 * Copies specified number of characters from reader to output stream using buffer.
+	 * Copies specified number of characters from reader to output stream using buffer - using jodd default encoding.
+     *
+     * @see JoddCore#encoding
 	 */
 	public static void copy(Reader input, OutputStream output, int charCount) throws IOException {
 		copy(input, output, JoddCore.encoding, charCount);

--- a/jodd-core/src/main/java/jodd/io/StreamUtil.java
+++ b/jodd-core/src/main/java/jodd/io/StreamUtil.java
@@ -207,17 +207,19 @@ public class StreamUtil {
 	 * Copies reader to output stream using buffer and specified encoding.
 	 */
 	public static void copy(Reader input, OutputStream output, String encoding) throws IOException {
-		Writer out = new OutputStreamWriter(output, encoding);
-		copy(input, out);
-		out.flush();
+        try (Writer out = new OutputStreamWriter(output, encoding)) {
+            copy(input, out);
+            out.flush();
+        }
 	}
 	/**
 	 * Copies specified number of characters from reader to output stream using buffer and specified encoding.
 	 */
 	public static void copy(Reader input, OutputStream output, String encoding, int charCount) throws IOException {
-		Writer out = new OutputStreamWriter(output, encoding);
-		copy(input, out, charCount);
-		out.flush();
+        try (Writer out = new OutputStreamWriter(output, encoding)) {
+            copy(input, out, charCount);
+            out.flush();
+        }
 	}
 
 

--- a/jodd-core/src/test/java/jodd/io/StreamUtilTest.java
+++ b/jodd-core/src/test/java/jodd/io/StreamUtilTest.java
@@ -31,12 +31,7 @@ import jodd.util.StringUtil;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
-import java.io.IOException;
+import java.io.*;
 import java.net.URL;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -44,6 +39,7 @@ import static org.junit.jupiter.api.Assertions.*;
 public class StreamUtilTest {
 
 	protected String dataRoot;
+	File textFile;
 
 	@BeforeEach
 	public void setUp() throws Exception {
@@ -52,6 +48,7 @@ public class StreamUtilTest {
 		}
 		URL data = ClassLoaderUtil.getResourceUrl("jodd/io/data");
 		dataRoot = data.getFile();
+		textFile = new File(dataRoot, "file/a.txt");
 	}
 
 	@Test
@@ -111,28 +108,24 @@ public class StreamUtilTest {
 
 
 	@Test
-	public void testCompare() {
-		try {
-			File file = new File(dataRoot, "file/a.txt");
-			FileInputStream in1 = new FileInputStream(file);
+	public void testCompare() throws Exception {
+        File file = textFile;
+        FileInputStream in1 = new FileInputStream(file);
 
-			String content = "test file\r\n";
-			if (file.length() == 10) {
-				content = StringUtil.remove(content, '\r');
-			}
-			ByteArrayInputStream in2 = new ByteArrayInputStream(content.getBytes());
-			assertTrue(StreamUtil.compare(in1, in2));
-			StreamUtil.close(in2);
-			StreamUtil.close(in1);
-		} catch (IOException e) {
-			fail("StreamUtil.testCloneCompare " + e.toString());
-		}
+        String content = "test file\r\n";
+        if (file.length() == 10) {
+            content = StringUtil.remove(content, '\r');
+        }
+        ByteArrayInputStream in2 = new ByteArrayInputStream(content.getBytes());
+        assertTrue(StreamUtil.compare(in1, in2));
+        StreamUtil.close(in2);
+        StreamUtil.close(in1);
 	}
 
 	@Test
 	public void testGetBytes() {
 		try {
-			FileInputStream in = new FileInputStream(new File(dataRoot, "file/a.txt"));
+			FileInputStream in = new FileInputStream(textFile);
 			byte[] data = StreamUtil.readBytes(in);
 			StreamUtil.close(in);
 
@@ -140,7 +133,7 @@ public class StreamUtilTest {
 			s = StringUtil.remove(s, '\r');
 			assertEquals("test file\n", s);
 
-			in = new FileInputStream(new File(dataRoot, "file/a.txt"));
+			in = new FileInputStream(textFile);
 			String str = new String(StreamUtil.readChars(in));
 			StreamUtil.close(in);
 			str = StringUtil.remove(str, '\r');
@@ -149,4 +142,17 @@ public class StreamUtilTest {
 			fail("StreamUtil.testGetBytes " + e.toString());
 		}
 	}
+
+    @Test
+    public void testCompareReaderInstances() throws Exception {
+
+        boolean actual;
+        try (FileReader input_1 = new FileReader(textFile); FileReader input_2 = new FileReader(textFile)) {
+            actual = StreamUtil.compare(input_1, input_2);
+        }
+
+        // asserts
+        assertTrue(actual);
+    }
+
 }

--- a/jodd-core/src/test/java/jodd/io/StreamUtilTest.java
+++ b/jodd-core/src/test/java/jodd/io/StreamUtilTest.java
@@ -38,8 +38,8 @@ import static org.junit.jupiter.api.Assertions.*;
 
 public class StreamUtilTest {
 
-	protected String dataRoot;
-	File textFile;
+	private String dataRoot;
+	private File textFile;
 
 	@BeforeEach
 	public void setUp() throws Exception {

--- a/jodd-core/src/test/java/jodd/io/StreamUtilTest.java
+++ b/jodd-core/src/test/java/jodd/io/StreamUtilTest.java
@@ -155,10 +155,10 @@ class StreamUtilTest {
         }
 
         @Test
-        void testCompareWithInputStreams_ExpectedSuccessfulCompare() throws Exception {
+        void testCompareWithInputStreams_ExpectedSuccessfulCompare(TestInfo testInfo) throws Exception {
 
             final String text = "jodd makes fun!" + System.lineSeparator();
-            final File file = new File(StreamUtilTest.BASE_DIR, "testCompareWithInputStreams_ExpectedSuccessfulCompare.txt");
+            final File file = new File(StreamUtilTest.BASE_DIR, testInfo.getTestMethod().get().getName() + ".txt");
             FileUtil.writeString(file, text, "UTF-8");
 
             boolean actual;
@@ -173,10 +173,10 @@ class StreamUtilTest {
         }
 
         @Test
-        void testCompareWithInputStreams_ExpectedNoSuccessfulCompare() throws Exception {
+        void testCompareWithInputStreams_ExpectedNoSuccessfulCompare(TestInfo testInfo) throws Exception {
 
             final String text = "jodd makes fun!";
-            final File file = new File(StreamUtilTest.BASE_DIR, "testCompareWithInputStreams_ExpectedNoSuccessfulCompare.txt");
+            final File file = new File(StreamUtilTest.BASE_DIR, testInfo.getTestMethod().get().getName() + ".txt");
             FileUtil.writeString(file, " " + text, "UTF-8");
 
             boolean actual;
@@ -276,10 +276,10 @@ class StreamUtilTest {
 
             @ParameterizedTest
             @MethodSource("testdata")
-            void testReadChars_InputStream_CharCount_0(char[] expected, String text, int charCount ) throws Exception {
+            void testReadChars_InputStream_CharCount_0(char[] expected, String text, int charCount, TestInfo testInfo ) throws Exception {
 
                 final int random = MathUtil.randomInt(1, 2500);
-                final File file = new File(BASE_DIR, "testReadChars_InputStream_CharCount_0.txt." + random);
+                final File file = new File(BASE_DIR, testInfo.getTestMethod().get().getName() + "." + random);
 
                 FileUtil.writeString(file, text, "UTF-8");
 
@@ -296,7 +296,10 @@ class StreamUtilTest {
 
             Stream<Arguments> testdata() {
                 return Stream.of(
-                        Arguments.of("jodd".toCharArray(),"jodd", 34 )
+                        Arguments.of("jodd".toCharArray(),"jodd", 34 ),
+                        Arguments.of("jodd".toCharArray(),"jodd", 4 ),
+                        Arguments.of("jo".toCharArray(),"jodd", 2 ),
+                        Arguments.of("".toCharArray(),"jodd", 0 )
                 );
             }
 

--- a/jodd-core/src/test/java/jodd/io/StreamUtilTest.java
+++ b/jodd-core/src/test/java/jodd/io/StreamUtilTest.java
@@ -36,6 +36,9 @@ import java.net.URL;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+/**
+ * test class for {@link StreamUtil}
+ */
 public class StreamUtilTest {
 
 	private String dataRoot;

--- a/jodd-core/src/test/java/jodd/io/StreamUtilTest.java
+++ b/jodd-core/src/test/java/jodd/io/StreamUtilTest.java
@@ -107,7 +107,6 @@ public class StreamUtilTest {
 		StreamUtil.close(in);
 
 		JoddCore.ioBufferSize = temp;
-
 	}
 
 
@@ -125,8 +124,6 @@ public class StreamUtilTest {
 			assertTrue(StreamUtil.compare(in1, in2));
 			StreamUtil.close(in2);
 			StreamUtil.close(in1);
-		} catch (FileNotFoundException e) {
-			fail("StreamUtil.testCloneCompare " + e.toString());
 		} catch (IOException e) {
 			fail("StreamUtil.testCloneCompare " + e.toString());
 		}
@@ -148,8 +145,6 @@ public class StreamUtilTest {
 			StreamUtil.close(in);
 			str = StringUtil.remove(str, '\r');
 			assertEquals("test file\n", str);
-		} catch (FileNotFoundException e) {
-			fail("StreamUtil.testGetBytes " + e.toString());
 		} catch (IOException e) {
 			fail("StreamUtil.testGetBytes " + e.toString());
 		}

--- a/jodd-core/src/test/java/jodd/io/StreamUtilTest.java
+++ b/jodd-core/src/test/java/jodd/io/StreamUtilTest.java
@@ -125,7 +125,7 @@ public class StreamUtilTest {
 	}
 
     @Test
-    public void testCompareReaderInstances() throws Exception {
+    public void testCompareWithReaderInstances_ExpectedSuccessfulCompare() throws Exception {
 
         boolean actual;
         try (FileReader input_1 = new FileReader(textFile); FileReader input_2 = new FileReader(textFile)) {
@@ -134,6 +134,19 @@ public class StreamUtilTest {
 
         // asserts
         assertTrue(actual);
+    }
+
+    @Test
+    public void testCompareWithReaderInstances_ExpectedNotSuccessfulCompare() throws Exception {
+
+        boolean actual;
+
+        try (FileReader input_1 = new FileReader(textFile); CharArrayReader input_2 = new CharArrayReader(new char[] {'t','e','s','t',' ','f','i','l','e','!'})) {
+            actual = StreamUtil.compare(input_1, input_2);
+        }
+
+        // asserts
+        assertFalse(actual);
     }
 
 }

--- a/jodd-core/src/test/java/jodd/io/StreamUtilTest.java
+++ b/jodd-core/src/test/java/jodd/io/StreamUtilTest.java
@@ -52,39 +52,28 @@ public class StreamUtilTest {
 	}
 
 	@Test
-	public void testCopy() {
+	public void testCopy() throws Exception {
 		ByteArrayInputStream in = new ByteArrayInputStream("input".getBytes());
 		ByteArrayOutputStream out = new ByteArrayOutputStream();
-		try {
-			StreamUtil.copy(in, out);
-		} catch (IOException ioex) {
-			fail("StreamUtil.copy " + ioex.toString());
-		}
+        StreamUtil.copy(in, out);
 		assertEquals("input", out.toString());
 		StreamUtil.close(out);
 		StreamUtil.close(in);
 	}
 
 	@Test
-	public void testCopyWithSize() {
+	public void testCopyWithSize() throws Exception {
 		ByteArrayInputStream in = new ByteArrayInputStream("input".getBytes());
 		ByteArrayOutputStream out = new ByteArrayOutputStream();
-		try {
-			StreamUtil.copy(in, out, 3);
-		} catch (IOException ioex) {
-			fail("StreamUtil.copy " + ioex.toString());
-		}
-		assertEquals("inp", out.toString());
+        StreamUtil.copy(in, out, 3);
+
+        assertEquals("inp", out.toString());
 		StreamUtil.close(out);
 		StreamUtil.close(in);
 
 		in = new ByteArrayInputStream("input".getBytes());
 		out = new ByteArrayOutputStream();
-		try {
-			StreamUtil.copy(in, out, 5);
-		} catch (IOException ioex) {
-			fail("StreamUtil.copy " + ioex.toString());
-		}
+        StreamUtil.copy(in, out, 5);
 		assertEquals("input", out.toString());
 		StreamUtil.close(out);
 		StreamUtil.close(in);
@@ -94,11 +83,7 @@ public class StreamUtilTest {
 		JoddCore.ioBufferSize = 3;
 		in = new ByteArrayInputStream("input".getBytes());
 		out = new ByteArrayOutputStream();
-		try {
-			StreamUtil.copy(in, out, 5);
-		} catch (IOException ioex) {
-			fail("StreamUtil.copy " + ioex.toString());
-		}
+        StreamUtil.copy(in, out, 5);
 		assertEquals("input", out.toString());
 		StreamUtil.close(out);
 		StreamUtil.close(in);
@@ -123,24 +108,20 @@ public class StreamUtilTest {
 	}
 
 	@Test
-	public void testGetBytes() {
-		try {
-			FileInputStream in = new FileInputStream(textFile);
-			byte[] data = StreamUtil.readBytes(in);
-			StreamUtil.close(in);
+	public void testGetBytes() throws Exception {
+        FileInputStream in = new FileInputStream(textFile);
+        byte[] data = StreamUtil.readBytes(in);
+        StreamUtil.close(in);
 
-			String s = new String(data);
-			s = StringUtil.remove(s, '\r');
-			assertEquals("test file\n", s);
+        String s = new String(data);
+        s = StringUtil.remove(s, '\r');
+        assertEquals("test file\n", s);
 
-			in = new FileInputStream(textFile);
-			String str = new String(StreamUtil.readChars(in));
-			StreamUtil.close(in);
-			str = StringUtil.remove(str, '\r');
-			assertEquals("test file\n", str);
-		} catch (IOException e) {
-			fail("StreamUtil.testGetBytes " + e.toString());
-		}
+        in = new FileInputStream(textFile);
+        String str = new String(StreamUtil.readChars(in));
+        StreamUtil.close(in);
+        str = StringUtil.remove(str, '\r');
+        assertEquals("test file\n", str);
 	}
 
     @Test

--- a/jodd-core/src/test/java/jodd/io/StreamUtilTest.java
+++ b/jodd-core/src/test/java/jodd/io/StreamUtilTest.java
@@ -152,4 +152,42 @@ public class StreamUtilTest {
         assertFalse(actual);
     }
 
+    @Test
+    public void testCopyReaderWriterCharCount() throws Exception {
+	    // charCount < input data
+        try (CharArrayReader reader = new CharArrayReader(new char[]{'j', 'o', 'd', 'd', ' ', 'i', 's', ' ', 'c', 'o', 'o', 'l'});
+             StringWriter writer = new StringWriter()) {
+
+            final String expected = "jodd";
+
+            StreamUtil.copy(reader, writer, 4);
+
+            // asserts
+            assertEquals(expected, writer.toString());
+        }
+
+        // charCount == input data
+        try (CharArrayReader reader = new CharArrayReader(new char[]{'j', 'o', 'd', 'd', ' ', 'i', 's', ' ', 'c', 'o', 'o', 'l'});
+             StringWriter writer = new StringWriter()) {
+
+            final String expected = "jodd is cool";
+
+            StreamUtil.copy(reader, writer, 12);
+
+            // asserts
+            assertEquals(expected, writer.toString());
+        }
+
+        // charCount > input data
+        try (CharArrayReader reader = new CharArrayReader(new char[]{'j', 'o', 'd', 'd', ' ', 'i', 's', ' ', 'c', 'o', 'o', 'l'});
+             StringWriter writer = new StringWriter()) {
+
+            final String expected = "jodd is cool";
+
+            StreamUtil.copy(reader, writer, 456);
+
+            // asserts
+            assertEquals(expected, writer.toString());
+        }
+    }
 }


### PR DESCRIPTION
Hi,

PR consists of :
- small enhancements of class `jodd.io.StreamUtil`
  - update javadoc
  - usage of try-with-resources at 2 methods
- huge refactoring of `jodd.io.StreamUtilTest`
  - new structure of tests -> tests are grouped in nested classes
  - usage of [Parameterized Tests](http://junit.org/junit5/docs/current/user-guide/#writing-tests-parameterized-tests) (needed new dependency _org.junit.jupiter:junit-jupiter-params_)

Regarding to #453 :
I have used public modifier to top level class and all test methods. The nested classes have package-private modifier - but a change to public is no problem ;-)
Additionally all test methods start with `test` prefix.

I look forward to comments and a review!

Bye,
Sascha