### PR TITLE
update javadoc -> only benchmark results of class itself

### DIFF
--- a/jodd-core/src/perf/java/jodd/util/Base64Benchmark.java
+++ b/jodd-core/src/perf/java/jodd/util/Base64Benchmark.java
@@ -67,30 +67,6 @@ import java.io.UnsupportedEncodingException;
  * Base64Benchmark.encode_Apache_Base64                                          thrpt   10     425022.574 ±    6719.127  ops/s
  * Base64Benchmark.encode_Java_Base64                                            thrpt   10    2317106.258 ±   48035.465  ops/s
  * Base64Benchmark.encode_Jodd_Base64                                            thrpt   10    2308577.816 ±  111663.488  ops/s
- * CharUtilIWhitespaceBenchmark.isWhitespace_Java                                thrpt   10   14198643.215 ±  132409.477  ops/s
- * CharUtilIWhitespaceBenchmark.isWhitespace_Jodd                                thrpt   10  340392811.038 ± 5584431.305  ops/s
- * StringBandBenchmark.string2                                                   thrpt   10   35891067.323 ± 1044617.014  ops/s
- * StringBandBenchmark.string3                                                   thrpt   10   16578168.807 ± 1528910.415  ops/s
- * StringBandBenchmark.stringBand2                                               thrpt   10   26738669.712 ± 2399655.941  ops/s
- * StringBandBenchmark.stringBand3                                               thrpt   10   17382025.209 ± 8201893.387  ops/s
- * StringUtilReplaceBenchmark.apacheStringUtilsReplaceLongStringNoMatch          thrpt   21   30452115.098 ±  673893.391  ops/s
- * StringUtilReplaceBenchmark.apacheStringUtilsReplaceLongStringOneMatch         thrpt   21    7939333.083 ±  159884.176  ops/s
- * StringUtilReplaceBenchmark.apacheStringUtilsReplaceLongStringSeveralMatches   thrpt   21    4572341.549 ±  190924.651  ops/s
- * StringUtilReplaceBenchmark.apacheStringUtilsReplaceShortStringNoMatch         thrpt   21  200849811.354 ± 6004094.222  ops/s
- * StringUtilReplaceBenchmark.apacheStringUtilsReplaceShortStringOneMatch        thrpt   21   12733470.739 ±  204528.150  ops/s
- * StringUtilReplaceBenchmark.apacheStringUtilsReplaceShortStringSeveralMatches  thrpt   21    7037310.309 ±  240382.430  ops/s
- * StringUtilReplaceBenchmark.stringReplaceLongStringNoMatch                     thrpt   21    5985542.910 ±  145759.366  ops/s
- * StringUtilReplaceBenchmark.stringReplaceLongStringOneMatch                    thrpt   21    1760430.973 ±   61879.332  ops/s
- * StringUtilReplaceBenchmark.stringReplaceLongStringSeveralMatches              thrpt   21    1338152.084 ±   38966.154  ops/s
- * StringUtilReplaceBenchmark.stringReplaceShortStringNoMatch                    thrpt   21    6944636.309 ±  283722.384  ops/s
- * StringUtilReplaceBenchmark.stringReplaceShortStringOneMatch                   thrpt   21    4071359.788 ±  166071.428  ops/s
- * StringUtilReplaceBenchmark.stringReplaceShortStringSeveralMatches             thrpt   21    2660695.634 ±  247642.047  ops/s
- * StringUtilReplaceBenchmark.stringUtilReplaceLongStringNoMatch                 thrpt   21   30705952.332 ±  441294.722  ops/s
- * StringUtilReplaceBenchmark.stringUtilReplaceLongStringOneMatch                thrpt   21    9057931.761 ±  411462.754  ops/s
- * StringUtilReplaceBenchmark.stringUtilReplaceLongStringSeveralMatches          thrpt   21    4688956.630 ±  185023.595  ops/s
- * StringUtilReplaceBenchmark.stringUtilReplaceShortStringNoMatch                thrpt   21  203959018.661 ± 5308589.795  ops/s
- * StringUtilReplaceBenchmark.stringUtilReplaceShortStringOneMatch               thrpt   21   17706892.816 ± 1073079.702  ops/s
- * StringUtilReplaceBenchmark.stringUtilReplaceShortStringSeveralMatches         thrpt   21    8975422.713 ±  225388.842  ops/s
  * </pre>
  */
 @Fork(1)

--- a/jodd-core/src/perf/java/jodd/util/CharUtilIWhitespaceBenchmark.java
+++ b/jodd-core/src/perf/java/jodd/util/CharUtilIWhitespaceBenchmark.java
@@ -42,42 +42,14 @@ import org.openjdk.jmh.annotations.Warmup;
  *
  * Run:
  * <code>
- * gw :jodd-core:perf -PCharUtilIsWhitespaceBenchmark
+ * gw :jodd-core:perf -PCharUtilIWhitespaceBenchmark
  * </code>
  * <p>
  * Results:
  * <pre>
  * Benchmark                                                                      Mode  Cnt          Score          Error  Units
- * Base64Benchmark.decode_Apache_Base64                                          thrpt   10     374448.183 ±     9019.145  ops/s
- * Base64Benchmark.decode_Java_Base64                                            thrpt   10    1158992.087 ±    58429.770  ops/s
- * Base64Benchmark.decode_Jodd_Base64                                            thrpt   10    1995540.839 ±    69155.682  ops/s
- * Base64Benchmark.encode_Apache_Base64                                          thrpt   10     390833.312 ±    32782.847  ops/s
- * Base64Benchmark.encode_Java_Base64                                            thrpt   10    2107696.944 ±    70326.325  ops/s
- * Base64Benchmark.encode_Jodd_Base64                                            thrpt   10    2109913.095 ±    63445.711  ops/s
  * CharUtilIWhitespaceBenchmark.isWhitespace_Java                                thrpt   10   13583774.700 ±   213854.012  ops/s
  * CharUtilIWhitespaceBenchmark.isWhitespace_Jodd                                thrpt   10  328635894.937 ± 15281486.519  ops/s
- * StringBandBenchmark.string2                                                   thrpt   10   31029353.194 ±  1811678.405  ops/s
- * StringBandBenchmark.string3                                                   thrpt   10   14626248.717 ±   790672.725  ops/s
- * StringBandBenchmark.stringBand2                                               thrpt   10   17526869.533 ±  5751065.262  ops/s
- * StringBandBenchmark.stringBand3                                               thrpt   10   15486452.961 ±  1382006.825  ops/s
- * StringUtilReplaceBenchmark.apacheStringUtilsReplaceLongStringNoMatch          thrpt   21   27395231.094 ±  2330643.753  ops/s
- * StringUtilReplaceBenchmark.apacheStringUtilsReplaceLongStringOneMatch         thrpt   21    7587161.270 ±   615480.263  ops/s
- * StringUtilReplaceBenchmark.apacheStringUtilsReplaceLongStringSeveralMatches   thrpt   21    4427557.812 ±   290238.935  ops/s
- * StringUtilReplaceBenchmark.apacheStringUtilsReplaceShortStringNoMatch         thrpt   21  195470162.926 ±  8848838.744  ops/s
- * StringUtilReplaceBenchmark.apacheStringUtilsReplaceShortStringOneMatch        thrpt   21   11076156.521 ±   944743.990  ops/s
- * StringUtilReplaceBenchmark.apacheStringUtilsReplaceShortStringSeveralMatches  thrpt   21    6587230.845 ±   589532.187  ops/s
- * StringUtilReplaceBenchmark.stringReplaceLongStringNoMatch                     thrpt   21    5562892.397 ±   485870.574  ops/s
- * StringUtilReplaceBenchmark.stringReplaceLongStringOneMatch                    thrpt   21    1779604.879 ±    62660.787  ops/s
- * StringUtilReplaceBenchmark.stringReplaceLongStringSeveralMatches              thrpt   21    1373842.844 ±    37593.982  ops/s
- * StringUtilReplaceBenchmark.stringReplaceShortStringNoMatch                    thrpt   21    7345620.559 ±   261438.288  ops/s
- * StringUtilReplaceBenchmark.stringReplaceShortStringOneMatch                   thrpt   21    4329321.076 ±    63065.136  ops/s
- * StringUtilReplaceBenchmark.stringReplaceShortStringSeveralMatches             thrpt   21    2866999.696 ±    46869.996  ops/s
- * StringUtilReplaceBenchmark.stringUtilReplaceLongStringNoMatch                 thrpt   21   30699600.817 ±   444331.453  ops/s
- * StringUtilReplaceBenchmark.stringUtilReplaceLongStringOneMatch                thrpt   21    9620813.037 ±   800151.267  ops/s
- * StringUtilReplaceBenchmark.stringUtilReplaceLongStringSeveralMatches          thrpt   21    5003350.550 ±   108551.326  ops/s
- * StringUtilReplaceBenchmark.stringUtilReplaceShortStringNoMatch                thrpt   21  206886806.152 ±  3385778.318  ops/s
- * StringUtilReplaceBenchmark.stringUtilReplaceShortStringOneMatch               thrpt   21   19054271.049 ±   592829.497  ops/s
- * StringUtilReplaceBenchmark.stringUtilReplaceShortStringSeveralMatches         thrpt   21    9453507.916 ±   181412.462  ops/s
  * </pre>
  */
 @Fork(1)

--- a/jodd-core/src/perf/java/jodd/util/StringBandBenchmark.java
+++ b/jodd-core/src/perf/java/jodd/util/StringBandBenchmark.java
@@ -41,36 +41,10 @@ import org.openjdk.jmh.annotations.Warmup;
  * Results:
  * <pre>
  * Benchmark                                                                      Mode  Cnt          Score          Error  Units
- * Base64Benchmark.decode_Apache_Base64                                          thrpt   10     423695.794 ±    28533.549  ops/s
- * Base64Benchmark.decode_Java_Base64                                            thrpt   10    1265582.300 ±    33158.561  ops/s
- * Base64Benchmark.decode_Jodd_Base64                                            thrpt   10    2153548.899 ±    61355.151  ops/s
- * Base64Benchmark.encode_Apache_Base64                                          thrpt   10     437170.067 ±     9896.702  ops/s
- * Base64Benchmark.encode_Java_Base64                                            thrpt   10    2345220.500 ±    76198.905  ops/s
- * Base64Benchmark.encode_Jodd_Base64                                            thrpt   10    2369976.451 ±   111352.672  ops/s
- * CharUtilIWhitespaceBenchmark.isWhitespace_Java                                thrpt   10   14331949.693 ±   463362.791  ops/s
- * CharUtilIWhitespaceBenchmark.isWhitespace_Jodd                                thrpt   10  346290107.476 ± 13771853.466  ops/s
  * StringBandBenchmark.string2                                                   thrpt   10   36780068.335 ±  1184388.514  ops/s
  * StringBandBenchmark.string3                                                   thrpt   10   16942855.967 ±   853722.889  ops/s
  * StringBandBenchmark.stringBand2                                               thrpt   10   27967094.903 ±   724524.916  ops/s
  * StringBandBenchmark.stringBand3                                               thrpt   10   20909453.929 ±   788585.662  ops/s
- * StringUtilReplaceBenchmark.apacheStringUtilsReplaceLongStringNoMatch          thrpt   21   30955737.221 ±   269888.167  ops/s
- * StringUtilReplaceBenchmark.apacheStringUtilsReplaceLongStringOneMatch         thrpt   21    8267635.892 ±   268938.864  ops/s
- * StringUtilReplaceBenchmark.apacheStringUtilsReplaceLongStringSeveralMatches   thrpt   21    4769646.746 ±   141350.031  ops/s
- * StringUtilReplaceBenchmark.apacheStringUtilsReplaceShortStringNoMatch         thrpt   21  203482907.693 ±  6869116.349  ops/s
- * StringUtilReplaceBenchmark.apacheStringUtilsReplaceShortStringOneMatch        thrpt   21   13189304.405 ±   225885.341  ops/s
- * StringUtilReplaceBenchmark.apacheStringUtilsReplaceShortStringSeveralMatches  thrpt   21    7154996.719 ±   267083.568  ops/s
- * StringUtilReplaceBenchmark.stringReplaceLongStringNoMatch                     thrpt   21    6134190.139 ±   211500.974  ops/s
- * StringUtilReplaceBenchmark.stringReplaceLongStringOneMatch                    thrpt   21    1835404.310 ±    48717.545  ops/s
- * StringUtilReplaceBenchmark.stringReplaceLongStringSeveralMatches              thrpt   21    1378140.957 ±    26445.602  ops/s
- * StringUtilReplaceBenchmark.stringReplaceShortStringNoMatch                    thrpt   21    7332052.151 ±   279770.916  ops/s
- * StringUtilReplaceBenchmark.stringReplaceShortStringOneMatch                   thrpt   21    4229701.851 ±   330467.125  ops/s
- * StringUtilReplaceBenchmark.stringReplaceShortStringSeveralMatches             thrpt   21    2886766.328 ±    48066.661  ops/s
- * StringUtilReplaceBenchmark.stringUtilReplaceLongStringNoMatch                 thrpt   21   31050291.182 ±   309338.753  ops/s
- * StringUtilReplaceBenchmark.stringUtilReplaceLongStringOneMatch                thrpt   21   10034031.465 ±   157083.396  ops/s
- * StringUtilReplaceBenchmark.stringUtilReplaceLongStringSeveralMatches          thrpt   21    4991154.668 ±    93731.674  ops/s
- * StringUtilReplaceBenchmark.stringUtilReplaceShortStringNoMatch                thrpt   21  207654544.276 ±  2141371.945  ops/s
- * StringUtilReplaceBenchmark.stringUtilReplaceShortStringOneMatch               thrpt   21   18967291.468 ±   728185.876  ops/s
- * StringUtilReplaceBenchmark.stringUtilReplaceShortStringSeveralMatches         thrpt   21    9217583.423 ±   266449.122  ops/s
  * </pre>
  */
 @Fork(1)

--- a/jodd-core/src/perf/java/jodd/util/StringUtilReplaceBenchmark.java
+++ b/jodd-core/src/perf/java/jodd/util/StringUtilReplaceBenchmark.java
@@ -50,18 +50,6 @@ import org.openjdk.jmh.annotations.Warmup;
  * Results:
  * <pre>
  * Benchmark                                                                      Mode  Cnt          Score          Error  Units
- * Base64Benchmark.decode_Apache_Base64                                          thrpt   10     437382.725 ±    17632.287  ops/s
- * Base64Benchmark.decode_Java_Base64                                            thrpt   10    1128600.920 ±   128620.707  ops/s
- * Base64Benchmark.decode_Jodd_Base64                                            thrpt   10    1996963.313 ±    60933.567  ops/s
- * Base64Benchmark.encode_Apache_Base64                                          thrpt   10     444188.781 ±    17254.237  ops/s
- * Base64Benchmark.encode_Java_Base64                                            thrpt   10    2372845.229 ±   161849.449  ops/s
- * Base64Benchmark.encode_Jodd_Base64                                            thrpt   10    2421585.489 ±    98594.888  ops/s
- * CharUtilIWhitespaceBenchmark.isWhitespace_Java                                thrpt   10   14734579.261 ±   254027.348  ops/s
- * CharUtilIWhitespaceBenchmark.isWhitespace_Jodd                                thrpt   10  349237222.872 ± 15785727.034  ops/s
- * StringBandBenchmark.string2                                                   thrpt   10   37818400.146 ±   466186.699  ops/s
- * StringBandBenchmark.string3                                                   thrpt   10   17354566.314 ±   355497.906  ops/s
- * StringBandBenchmark.stringBand2                                               thrpt   10   27789621.987 ±  1554213.757  ops/s
- * StringBandBenchmark.stringBand3                                               thrpt   10   21079979.110 ±  1827100.524  ops/s
  * StringUtilReplaceBenchmark.apacheStringUtilsReplaceLongStringNoMatch          thrpt   21   30664291.493 ±   506821.904  ops/s
  * StringUtilReplaceBenchmark.apacheStringUtilsReplaceLongStringOneMatch         thrpt   21    8469800.841 ±   115709.770  ops/s
  * StringUtilReplaceBenchmark.apacheStringUtilsReplaceLongStringSeveralMatches   thrpt   21    4844528.121 ±   143725.969  ops/s


### PR DESCRIPTION
Hi,

PR updates javadoc of the jodd util - benchmarks that results of the class itself is only listed in javadoc.


Bye,
Sascha