### PR TITLE
Update build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -374,7 +374,7 @@ configure(javaModules()) {
 			configure(options) {
 				windowTitle 'Jodd API Documentation'
 				docTitle "$project.moduleName $project.version API Documentation"
-				bottom = 'Copyright &#169; 2003-2013 <a href="http://jodd.org">Jodd Team</a>'
+				bottom = 'Copyright &#169; 2003-present <a href="http://jodd.org">Jodd Team</a>'
 				breakIterator = true
 				author = false
 				encoding = 'UTF-8'


### PR DESCRIPTION
- update `javadoc` task
   -  change :  2003-2013 -> 2003-present
- questions for `javadocAll` task
  - source = 1.9 -> correct?! Within task javaDoc , value is 1.8
  - bottom contains "2003-2016" - also an update necessary?

- `exclude`s within tasks `javadoc` and `javadocAll` are different. It is cleaner having the same excludes, isn't it?


Bye,
Sascha