### PR TITLE
Base64 extension

### DIFF
--- a/jodd-core/src/main/java/jodd/util/Base64.java
+++ b/jodd-core/src/main/java/jodd/util/Base64.java
@@ -102,7 +102,7 @@ public class Base64 {
 	/**
 	 * Decodes a BASE64 encoded char array.
 	 */
-	public byte[] decode(char[] arr) {
+	public static byte[] decode(char[] arr) {
 		int length = arr.length;
 		if (length == 0) {
 			return new byte[0];

--- a/jodd-core/src/test/java/jodd/util/Base64Test.java
+++ b/jodd-core/src/test/java/jodd/util/Base64Test.java
@@ -32,11 +32,11 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class Base64Test {
 
-	final String text = "Man is distinguished, not only by his reason, but by this singular passion from other animals," +
+	private final String text = "Man is distinguished, not only by his reason, but by this singular passion from other animals," +
 			" which is a lust of the mind, that by a perseverance of delight in the continued and indefatigable generation of knowledge," +
 			" exceeds the short vehemence of any carnal pleasure.";
 
-	final String enc = "TWFuIGlzIGRpc3Rpbmd1aXNoZWQsIG5vdCBvbmx5IGJ5IGhpcyByZWFzb24sIGJ1dCBieSB0aGlz" +
+	private final String enc = "TWFuIGlzIGRpc3Rpbmd1aXNoZWQsIG5vdCBvbmx5IGJ5IGhpcyByZWFzb24sIGJ1dCBieSB0aGlz" +
 			"IHNpbmd1bGFyIHBhc3Npb24gZnJvbSBvdGhlciBhbmltYWxzLCB3aGljaCBpcyBhIGx1c3Qgb2Yg" +
 			"dGhlIG1pbmQsIHRoYXQgYnkgYSBwZXJzZXZlcmFuY2Ugb2YgZGVsaWdodCBpbiB0aGUgY29udGlu" +
 			"dWVkIGFuZCBpbmRlZmF0aWdhYmxlIGdlbmVyYXRpb24gb2Yga25vd2xlZGdlLCBleGNlZWRzIHRo" +

--- a/jodd-core/src/test/java/jodd/util/Base64Test.java
+++ b/jodd-core/src/test/java/jodd/util/Base64Test.java
@@ -32,11 +32,11 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class Base64Test {
 
-	String text = "Man is distinguished, not only by his reason, but by this singular passion from other animals," +
+	final String text = "Man is distinguished, not only by his reason, but by this singular passion from other animals," +
 			" which is a lust of the mind, that by a perseverance of delight in the continued and indefatigable generation of knowledge," +
 			" exceeds the short vehemence of any carnal pleasure.";
 
-	String enc = "TWFuIGlzIGRpc3Rpbmd1aXNoZWQsIG5vdCBvbmx5IGJ5IGhpcyByZWFzb24sIGJ1dCBieSB0aGlz" +
+	final String enc = "TWFuIGlzIGRpc3Rpbmd1aXNoZWQsIG5vdCBvbmx5IGJ5IGhpcyByZWFzb24sIGJ1dCBieSB0aGlz" +
 			"IHNpbmd1bGFyIHBhc3Npb24gZnJvbSBvdGhlciBhbmltYWxzLCB3aGljaCBpcyBhIGx1c3Qgb2Yg" +
 			"dGhlIG1pbmQsIHRoYXQgYnkgYSBwZXJzZXZlcmFuY2Ugb2YgZGVsaWdodCBpbiB0aGUgY29udGlu" +
 			"dWVkIGFuZCBpbmRlZmF0aWdhYmxlIGdlbmVyYXRpb24gb2Yga25vd2xlZGdlLCBleGNlZWRzIHRo" +
@@ -83,5 +83,16 @@ class Base64Test {
 		decoded = Base64.decodeToString(encoded);
 
 		assertEquals(utf8string, decoded);
+	}
+	
+	@Test
+	void testDecode_charArray() {
+		final char[] input = enc.toCharArray();
+
+		final byte[] actual_byteArray = Base64.decode(input);
+		final String actual_string = new String(actual_byteArray);
+
+		// asserts
+		assertEquals(text, actual_string);
 	}
 }


### PR DESCRIPTION
Hi,

PR consists of:
- `jodd.uti.Base64`
  - change from "public byte[] decode(char[] arr)" -> "public static byte[] decode(char[] arr)"
    - Do any reasons exist that method is not static?
- `jodd.uti.Base64Test`
  - test method added for "public static byte[] decode(char[] arr)"


Bye,
Sascha
