### PR TITLE
DateTimeStamp tests & small enhancements

### DIFF
--- a/jodd-core/src/main/java/jodd/datetime/DateTimeStamp.java
+++ b/jodd-core/src/main/java/jodd/datetime/DateTimeStamp.java
@@ -237,11 +237,11 @@ public class DateTimeStamp implements Comparable, Serializable, Cloneable {
 
 	@Override
 	public boolean equals(Object object) {
+		if (object == null || this.getClass() != object.getClass()) {
+			return false;
+		}
 		if (this == object) {
 			return true;
-		}
-		if (this.getClass() != object.getClass()) {
-			return false;
 		}
 		DateTimeStamp stamp = (DateTimeStamp) object;
 		return  (stamp.year == this.year) &&

--- a/jodd-core/src/main/java/jodd/datetime/DateTimeStamp.java
+++ b/jodd-core/src/main/java/jodd/datetime/DateTimeStamp.java
@@ -26,6 +26,7 @@
 package jodd.datetime;
 
 import jodd.util.HashCode;
+import jodd.util.StringBand;
 
 import java.io.Serializable;
 
@@ -227,7 +228,7 @@ public class DateTimeStamp implements Comparable, Serializable, Cloneable {
 	 */
 	@Override
 	public String toString() {
-		return new StringBuilder(25).append(year).append('-').append(month)
+		return new StringBand(13).append(year).append('-').append(month)
 				.append('-').append(day).append(' ').append(hour).append(':')
 				.append(minute).append(':').append(second).append('.')
 				.append(millisecond).toString();

--- a/jodd-core/src/test/java/jodd/datetime/DateTimeStampTest.java
+++ b/jodd-core/src/test/java/jodd/datetime/DateTimeStampTest.java
@@ -58,7 +58,7 @@ class DateTimeStampTest {
 	class Equals {
 
 		@ParameterizedTest
-		@MethodSource("testData_testCompareTo")
+		@MethodSource("testData_testEquals")
 		void testEquals(final boolean expected, final DateTimeStamp input_1, final Object input_2) {
 			final boolean actual = input_1.equals(input_2);
 
@@ -66,7 +66,7 @@ class DateTimeStampTest {
 			assertEquals(expected, actual);
 		}
 
-		private Collection<Arguments> testData_testCompareTo () {
+		private Collection<Arguments> testData_testEquals () {
 			final List<Arguments> params = new ArrayList<>();
 
 			{

--- a/jodd-core/src/test/java/jodd/datetime/DateTimeStampTest.java
+++ b/jodd-core/src/test/java/jodd/datetime/DateTimeStampTest.java
@@ -2,6 +2,7 @@ package jodd.datetime;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -96,5 +97,17 @@ class DateTimeStampTest {
 
 			return params;
 		}
+	}
+
+	@Test
+	void testToString() {
+
+		final String expected = "2017-12-12 11:56:23.12";
+		final DateTimeStamp input = new DateTimeStamp(2017,12,12,11,56,23,12);
+
+		final String actual = input.toString();
+
+		// asserts
+		assertEquals(expected, actual);
 	}
 }

--- a/jodd-core/src/test/java/jodd/datetime/DateTimeStampTest.java
+++ b/jodd-core/src/test/java/jodd/datetime/DateTimeStampTest.java
@@ -1,0 +1,100 @@
+package jodd.datetime;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Date;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class DateTimeStampTest {
+
+	@Nested
+	@DisplayName("tests for DateTimeStamp#compareTo")
+	@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+	class CompareTo {
+
+		@ParameterizedTest
+		@MethodSource("testData_testCompareTo")
+		void testCompareTo(final int expected, final DateTimeStamp input_1, final DateTimeStamp input_2) {
+			final int actual = input_1.compareTo(input_2);
+
+			// asserts
+			assertEquals(expected, actual);
+		}
+
+		private Collection<Arguments> testData_testCompareTo () {
+			final List<Arguments> params = new ArrayList<>();
+
+			{
+				params.add(Arguments.of(0, new DateTimeStamp(2017,12,12,11,56,23,11),
+						new DateTimeStamp(2017,12,12,11,56,23,11)));
+			}
+
+			{
+				params.add(Arguments.of(-1, new DateTimeStamp(2017,12,12,11,56,23,11),
+						new DateTimeStamp(2017,12,12,11,56,23,12)));
+			}
+
+			{
+				params.add(Arguments.of(1, new DateTimeStamp(2017,12,12,11,56,23,12),
+						new DateTimeStamp(2017,12,12,11,56,23,11)));
+			}
+
+			return params;
+		}
+	}
+
+	@Nested
+	@DisplayName("tests for DateTimeStamp#equals")
+	@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+	class Equals {
+
+		@ParameterizedTest
+		@MethodSource("testData_testCompareTo")
+		void testEquals(final boolean expected, final DateTimeStamp input_1, final Object input_2) {
+			final boolean actual = input_1.equals(input_2);
+
+			// asserts
+			assertEquals(expected, actual);
+		}
+
+		private Collection<Arguments> testData_testCompareTo () {
+			final List<Arguments> params = new ArrayList<>();
+
+			{
+				params.add(Arguments.of(true, new DateTimeStamp(2017,12,12,11,56,23,11),
+						new DateTimeStamp(2017,12,12,11,56,23,11)));
+			}
+
+			{
+				final DateTimeStamp dateTimeStamp = new DateTimeStamp(2017, 12, 12, 11, 56, 23, 11);
+				params.add(Arguments.of(true, dateTimeStamp, dateTimeStamp));
+			}
+
+			{
+				params.add(Arguments.of(false, new DateTimeStamp(2017,12,12,11,56,23,12),
+						null));
+			}
+
+			{
+				params.add(Arguments.of(false, new DateTimeStamp(2017,12,12,11,56,23,12),
+						new Date()));
+			}
+
+			{
+				params.add(Arguments.of(false, new DateTimeStamp(2017,12,12,11,56,23,12),
+						new DateTimeStamp(2017,12,12,11,56,23,13)));
+			}
+
+			return params;
+		}
+	}
+}

--- a/jodd-core/src/test/java/jodd/datetime/DateTimeStampTest.java
+++ b/jodd-core/src/test/java/jodd/datetime/DateTimeStampTest.java
@@ -231,4 +231,48 @@ class DateTimeStampTest {
 		}
 	}
 
+	@Nested
+	@DisplayName("tests for DateTimeStamp#isEqualDate")
+	class IsEqualDate {
+
+		@Test
+		void is_equal() {
+			final DateTimeStamp input_1 = new DateTimeStamp(2017,12,12,11,56,23,12);
+			final DateTimeStamp input_2 = new DateTimeStamp(2017,12,12,33,11,44,77);
+
+			assertEquals(true, input_1.isEqualDate(input_2));
+		}
+
+		@Test
+		void is_not_equal_due_to_day() {
+			final DateTimeStamp input_1 = new DateTimeStamp(2017,12,12,11,56,23,12);
+			final DateTimeStamp input_2 = new DateTimeStamp(2017,12,11,11,56,23,12);
+
+			assertEquals(false, input_1.isEqualDate(input_2));
+		}
+
+	}
+
+	@Nested
+	@DisplayName("tests for DateTimeStamp#isEqualTime")
+	class IsEqualTime {
+
+		@Test
+		void is_equal() throws Exception {
+			final DateTimeStamp input_1 = new DateTimeStamp(2017,12,12,11,56,23,12);
+			final DateTimeStamp input_2 = new DateTimeStamp(2018,9,2,11,56,23,12);
+
+			assertEquals(true, input_1.isEqualTime(input_2));
+		}
+
+		@Test
+		void is_not_equal_due_to_hour() {
+			final DateTimeStamp input_1 = new DateTimeStamp(2017,12,12,11,56,23,12);
+			final DateTimeStamp input_2 = new DateTimeStamp(2018,11,23,10,56,23,12);
+
+			assertEquals(false, input_1.isEqualTime(input_2));
+		}
+
+	}
+
 }

--- a/jodd-core/src/test/java/jodd/datetime/DateTimeStampTest.java
+++ b/jodd-core/src/test/java/jodd/datetime/DateTimeStampTest.java
@@ -25,6 +25,8 @@
 
 package jodd.datetime;
 
+import jodd.util.ArraysUtil;
+import jodd.util.collection.IntArrayList;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -33,13 +35,10 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Date;
-import java.util.List;
+import java.util.*;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class DateTimeStampTest {
 
@@ -153,4 +152,83 @@ class DateTimeStampTest {
 		assertEquals(input.getSecond(), clone.getSecond());
 		assertEquals(input.getMillisecond(), clone.getMillisecond());
 	}
+
+	@Nested
+	@DisplayName("tests for DateTimeStamp#hashCode")
+	@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+	class HashCode {
+
+		@ParameterizedTest
+		@MethodSource("testdata_testHashCode")
+		void testHashCode(final boolean equals, final DateTimeStamp input_1 , final DateTimeStamp input_2) {
+
+			final int hash_1 = input_1.hashCode();
+			final int hash_2 = input_2.hashCode();
+
+			assertTrue(equals == (hash_1 == hash_2));
+		}
+
+		private Collection<Arguments> testdata_testHashCode() throws Exception {
+			final List<Arguments> params = new ArrayList<>();
+
+			// same hashcode
+			{
+				final DateTimeStamp input = new DateTimeStamp(2017,12,12,11,56,23,12);
+				params.add(Arguments.of(true, input, input.clone()));
+			}
+
+			// diff : year
+			{
+				final DateTimeStamp input_1 = new DateTimeStamp(2017,12,12,11,56,23,12);
+				final DateTimeStamp input_2 = new DateTimeStamp(2018,12,12,11,56,23,12);
+				params.add(Arguments.of(false, input_1, input_2));
+			}
+
+			// diff : month
+			{
+				final DateTimeStamp input_1 = new DateTimeStamp(2017,12,12,11,56,23,12);
+				final DateTimeStamp input_2 = new DateTimeStamp(2017,11,12,11,56,23,12);
+				params.add(Arguments.of(false, input_1, input_2));
+			}
+
+			// diff : day
+			{
+				final DateTimeStamp input_1 = new DateTimeStamp(2017,12,12,11,56,23,12);
+				final DateTimeStamp input_2 = new DateTimeStamp(2017,12,13,11,56,23,12);
+				params.add(Arguments.of(false, input_1, input_2));
+			}
+
+			// diff : hour
+			{
+				final DateTimeStamp input_1 = new DateTimeStamp(2017,12,12,11,56,23,12);
+				final DateTimeStamp input_2 = new DateTimeStamp(2017,12,12,10,56,23,12);
+				params.add(Arguments.of(false, input_1, input_2));
+			}
+
+			// diff : minute
+			{
+				final DateTimeStamp input_1 = new DateTimeStamp(2017,12,12,11,56,23,12);
+				final DateTimeStamp input_2 = new DateTimeStamp(2017,12,12,11,57,23,12);
+				params.add(Arguments.of(false, input_1, input_2));
+			}
+
+			// diff : second
+			{
+				final DateTimeStamp input_1 = new DateTimeStamp(2017,12,12,11,56,23,12);
+				final DateTimeStamp input_2 = new DateTimeStamp(2017,12,12,11,56,22,12);
+				params.add(Arguments.of(false, input_1, input_2));
+			}
+
+			// diff : ms
+			{
+				final DateTimeStamp input_1 = new DateTimeStamp(2017,12,12,11,56,23,12);
+				final DateTimeStamp input_2 = new DateTimeStamp(2017,12,12,11,56,23,11);
+				params.add(Arguments.of(false, input_1, input_2));
+			}
+
+			return params;
+
+		}
+	}
+
 }

--- a/jodd-core/src/test/java/jodd/datetime/DateTimeStampTest.java
+++ b/jodd-core/src/test/java/jodd/datetime/DateTimeStampTest.java
@@ -1,3 +1,28 @@
+// Copyright (c) 2003-present, Jodd Team (http://jodd.org)
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice,
+// this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
 package jodd.datetime;
 
 import org.junit.jupiter.api.DisplayName;

--- a/jodd-core/src/test/java/jodd/datetime/DateTimeStampTest.java
+++ b/jodd-core/src/test/java/jodd/datetime/DateTimeStampTest.java
@@ -39,6 +39,7 @@ import java.util.Date;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 class DateTimeStampTest {
 
@@ -134,5 +135,22 @@ class DateTimeStampTest {
 
 		// asserts
 		assertEquals(expected, actual);
+	}
+
+	@Test
+	void testClone() throws Exception {
+
+		final DateTimeStamp input = new DateTimeStamp(2017,12,12,11,56,23,12);
+
+		final DateTimeStamp clone = input.clone();
+
+		// asserts
+		assertEquals(input.getYear(), clone.getYear());
+		assertEquals(input.getMonth(), clone.getMonth());
+		assertEquals(input.getDay(), clone.getDay());
+		assertEquals(input.getHour(), clone.getHour());
+		assertEquals(input.getMinute(), clone.getMinute());
+		assertEquals(input.getSecond(), clone.getSecond());
+		assertEquals(input.getMillisecond(), clone.getMillisecond());
 	}
 }


### PR DESCRIPTION
Hi,

PR consists of : 
- enhancements `jodd.datetime.DateTimeStamp`
  - `toString` : usage of `StringBand` instead of `StringBuilder`
  - `equals` : `null` check added
- `jodd.datetime.DateTimeStampTest`
  - Added tests for almost all methodes

question regarding method `compareDateTo`:
Why is `java.lang.Object` as parameter class used? Why not `jodd.datetime.DateTimeStamp` ?


Bye,
Sascha