### PR TITLE
enhancements to DbQuery

### DIFF
--- a/jodd-db/src/main/java/jodd/db/DbCallResult.java
+++ b/jodd-db/src/main/java/jodd/db/DbCallResult.java
@@ -249,6 +249,40 @@ public class DbCallResult {
 		}
 	}
 
+	// ---------------------------------------------------------------- long
+
+	public long getLong(int index) {
+		try {
+			return statement.getLong(index);
+		} catch (SQLException sex) {
+			throw newGetParamError(index, sex);
+		}
+	}
+
+	public long getLong(String param) {
+		IntArrayList positions = query.getNamedParameterIndices(param);
+		try {
+			if (positions.size() == 1) {
+				return statement.getLong(positions.get(0));
+			}
+			throw newGetParamError(param);
+		} catch (SQLException sex) {
+			throw newGetParamError(param, sex);
+		}
+	}
+
+	public long[] getAllLong(String param) {
+		IntArrayList positions = query.getNamedParameterIndices(param);
+		long[] result = new long[positions.size()];
+		try {
+			for (int i = 0; i < positions.size(); i++) {
+				result[i] = statement.getLong(positions.get(i));
+			}
+			return result;
+		} catch (SQLException sex) {
+			throw newGetParamError(param, sex);
+		}
+	}
 
 	// ---------------------------------------------------------------- exception
 

--- a/jodd-db/src/main/java/jodd/db/DbQuery.java
+++ b/jodd-db/src/main/java/jodd/db/DbQuery.java
@@ -349,7 +349,7 @@ public class DbQuery<Q extends DbQuery> extends DbQueryBase<Q> {
 
 	public Q setLong(int index, Number value) {
 		if (value == null) {
-			setNull(index, Types.INTEGER);
+			setNull(index, Types.BIGINT);
 		}
 		else {
 			setLong(index, value.longValue());
@@ -359,7 +359,7 @@ public class DbQuery<Q extends DbQuery> extends DbQueryBase<Q> {
 
 	public Q setLong(String param, Number value) {
 		if (value == null) {
-			setNull(param, Types.INTEGER);
+			setNull(param, Types.BIGINT);
 		}
 		else {
 			setLong(param, value.longValue());

--- a/jodd-db/src/main/java/jodd/db/DbQuery.java
+++ b/jodd-db/src/main/java/jodd/db/DbQuery.java
@@ -367,6 +367,12 @@ public class DbQuery<Q extends DbQuery> extends DbQueryBase<Q> {
 		return (Q) this;
 	}
 
+	public Q outLong(int index) {
+		return registerOutParameter(index, Types.BIGINT);
+	}
+	public Q outLong(String param) {
+		return registerOutParameter(param, Types.BIGINT);
+	}
 
 	// ---------------------------------------------------------------- byte
 


### PR DESCRIPTION
Hi,

PR consist of : 
- support for datatype `long` as in / out - paramenter at stored procedures
- small fix at method `setLong` for null-values
  - usage of `BIGINT` instaed of `INTEGER`

Bye,
Sascha