### PR TITLE
[ci skip] Get more Open Source Helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 [![Stack Overflow](http://img.shields.io/badge/stack%20overflow-jodd-4183C4.svg)](http://stackoverflow.com/questions/tagged/jodd)
 [![BSD License](https://img.shields.io/github/license/oblac/jodd.svg)](http://jodd.org/license.html)
 [![Twitter](https://img.shields.io/twitter/url/https/github.com/oblac/jodd.svg?style=social)](https://twitter.com/intent/tweet?text=Wow:&url=%5Bobject%20Object%5D)
+[![Help Contribute to Open Source](https://www.codetriage.com/oblac/jodd/badges/users.svg)](https://www.codetriage.com/oblac/jodd)
 
 + Official web site (site & documentation): http://jodd.org/
 + GitHub page (5 min overview): http://oblac.github.io/jodd


### PR DESCRIPTION
[CodeTriage](https://www.codetriage.com/) is an app I have maintained
for the past 4-5 years with the goal of getting people involved in
Open Source projects like this one. The app sends subscribers a random
open issue for them to help "triage". For some languages you can also
suggested areas to add documentation.

The initial approach was inspired by seeing the work of the small
core team spending countless hours asking "what version was
this in" and "can you give us an example app". The idea is to
outsource these small interactions to a huge team of volunteers
and let the core team focus on their work.

I want to add a badge to the README of this project. The idea is to
provide an easy link for people to get started contributing to this
project. A badge indicates the number of people currently subscribed
to help the repo. The color is based off of open issues in the project.

Here are some examples of other projects that have a badge in their
README:

- https://github.com/crystal-lang/crystal
- https://github.com/rails/rails
- https://github.com/codetriage/codetriage

Thanks for building open source software, I would love to help you find some helpers.