### PR TITLE
MathUtilRandomBenchmark : small fix for int-Methods

### DIFF
--- a/jodd-core/src/perf/java/jodd/util/MathUtilRandomBenchmark.java
+++ b/jodd-core/src/perf/java/jodd/util/MathUtilRandomBenchmark.java
@@ -68,7 +68,7 @@ public class MathUtilRandomBenchmark {
 	}
 
 	@Benchmark
-	public long randomInt_with_Random() {
+	public int randomInt_with_Random() {
 		return int_inclusive + (int) (Math.random() * (int_exclusive - int_inclusive));
 	}
 
@@ -80,7 +80,7 @@ public class MathUtilRandomBenchmark {
 	}
 
 	@Benchmark
-	public long randomInt_with_ThreadLocalRandom() {
+	public int randomInt_with_ThreadLocalRandom() {
 		return MathUtil.randomInt(int_inclusive, int_exclusive);
 	}
 


### PR DESCRIPTION
the methods `randomInt_with_Random` and `randomInt_with_ThreadLocalRandom` use 'int' as return value now