### PR TITLE
Add two main function, md5 encrypt and simple sha1 encrypt

### DIFF
--- a/jodd-core/src/main/java/jodd/exception/SignatureCannotBeNullException.java
+++ b/jodd-core/src/main/java/jodd/exception/SignatureCannotBeNullException.java
@@ -25,7 +25,7 @@
 package jodd.exception;
 
 /**
- * SignatureCannotBeNullException
+ * SignatureCannotBeNullException.
  * @author zhangxin
  */
 public class SignatureCannotBeNullException extends IllegalArgumentException {

--- a/jodd-core/src/main/java/jodd/exception/SignatureCannotBeNullException.java
+++ b/jodd-core/src/main/java/jodd/exception/SignatureCannotBeNullException.java
@@ -1,0 +1,48 @@
+// Copyright (c) 2003-present, Jodd Team (http://jodd.org)
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice,
+// this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+package jodd.exception;
+
+/**
+ * SignatureCannotBeNullException
+ * @author zhangxin
+ */
+public class SignatureCannotBeNullException extends IllegalArgumentException {
+
+    public SignatureCannotBeNullException() {
+        super();
+    }
+
+    public SignatureCannotBeNullException(String s) {
+        super(s);
+    }
+
+    public SignatureCannotBeNullException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public SignatureCannotBeNullException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/jodd-core/src/main/java/jodd/util/MD5Util.java
+++ b/jodd-core/src/main/java/jodd/util/MD5Util.java
@@ -27,13 +27,16 @@ package jodd.util;
 import jodd.exception.SignatureCannotBeNullException;
 
 /**
- * MD5Util
+ * MD5Util.
  * @author zhangxin
  */
 public class MD5Util {
 
+    private MD5Util() {
+    }
+
     /**
-     * MD5 encrypts function
+     * MD5 encrypts function.
      *
      * @param message the character string will be encrypt
      * @return encrypt result
@@ -52,8 +55,7 @@ public class MD5Util {
      * @return compare result
      */
     public static boolean encode(String str, String signature) throws SignatureCannotBeNullException {
-        if (signature==null||"".equals(signature))
-        {
+        if (signature == null||"".equals(signature)) {
             throw new SignatureCannotBeNullException("The signature mustn't be null or none string");
         }
         return encode(str).equals(signature);

--- a/jodd-core/src/main/java/jodd/util/MD5Util.java
+++ b/jodd-core/src/main/java/jodd/util/MD5Util.java
@@ -1,0 +1,61 @@
+// Copyright (c) 2003-present, Jodd Team (http://jodd.org)
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice,
+// this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+package jodd.util;
+
+import jodd.exception.SignatureCannotBeNullException;
+
+/**
+ * MD5Util
+ * @author zhangxin
+ */
+public class MD5Util {
+
+    /**
+     * MD5 encrypts function
+     *
+     * @param message the character string will be encrypt
+     * @return encrypt result
+     */
+    public static String encode(String message) {
+
+        return SignUtil.encode("MD5", message);
+    }
+
+    /**
+     * MD5 encrypt，The string provided is encrypted with the MD5 encryption algorithm, and then compare with signature
+     * provided,if the signature is null or empty string, this method will throws SignatureCannotBeNullException.
+     *
+     * @param str the character string will be encrypt
+     * @param signature the signature message
+     * @return compare result
+     */
+    public static boolean encode(String str, String signature) throws SignatureCannotBeNullException {
+        if (signature==null||"".equals(signature))
+        {
+            throw new SignatureCannotBeNullException("The signature mustn't be null or none string");
+        }
+        return encode(str).equals(signature);
+    }
+}

--- a/jodd-core/src/main/java/jodd/util/SHA1Util.java
+++ b/jodd-core/src/main/java/jodd/util/SHA1Util.java
@@ -1,0 +1,77 @@
+// Copyright (c) 2003-present, Jodd Team (http://jodd.org)
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice,
+// this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+package jodd.util;
+
+import jodd.exception.SignatureCannotBeNullException;
+
+import java.util.Arrays;
+
+/**
+ * SHA1Util
+ * @author zhangxin
+ */
+public class SHA1Util {
+
+    /**
+     * SHA1 encrypts function, which determines whether the incoming parameters are sorted in the dictionary order
+     * according to the incoming values, and then encrypted using the SHA1 encryption algorithm.
+     *
+     * @param str the content will be encrypt
+     * @param flag the content need sort by dictionary order or not
+     * @return the encrypt result
+     */
+    public static String encode(String[] str,boolean flag) {
+        if (flag) {
+            // 字典序排序
+            Arrays.sort(str);
+        }
+        StringBuilder bigStr = new StringBuilder();
+        for (String message:str) {
+            bigStr.append(message);
+        }
+        // SHA1加密
+        return SignUtil.encode("SHA1", bigStr.toString()).toLowerCase();
+    }
+
+    /**
+     * SHA1 encryption will determine whether the incoming parameters are sorted in the dictionary order or not,
+     * and then encrypted using the SHA1 encryption algorithm. And then compare with signature, if the signature is null
+     * or empty string, this method will throws SignatureCannotBeNullException.
+     *
+     * @param str the character string will be encrypt
+     * @param flag the content need sort by dictionary order or not
+     * @param signature the signature message
+     * @return compare result
+     */
+    public static boolean encode(String[] str,boolean flag,String signature) throws SignatureCannotBeNullException {
+        if (signature==null||"".equals(signature))
+        {
+            throw new SignatureCannotBeNullException("The signature mustn't be null or none string");
+        }
+        return encode(str,flag).equals(signature);
+    }
+
+
+}

--- a/jodd-core/src/main/java/jodd/util/SHA1Util.java
+++ b/jodd-core/src/main/java/jodd/util/SHA1Util.java
@@ -29,10 +29,13 @@ import jodd.exception.SignatureCannotBeNullException;
 import java.util.Arrays;
 
 /**
- * SHA1Util
+ * SHA1Util.
  * @author zhangxin
  */
 public class SHA1Util {
+
+    private SHA1Util() {
+    }
 
     /**
      * SHA1 encrypts function, which determines whether the incoming parameters are sorted in the dictionary order
@@ -42,7 +45,7 @@ public class SHA1Util {
      * @param flag the content need sort by dictionary order or not
      * @return the encrypt result
      */
-    public static String encode(String[] str,boolean flag) {
+    public static String encode(String[] str, boolean flag) {
         if (flag) {
             // 字典序排序
             Arrays.sort(str);
@@ -65,12 +68,11 @@ public class SHA1Util {
      * @param signature the signature message
      * @return compare result
      */
-    public static boolean encode(String[] str,boolean flag,String signature) throws SignatureCannotBeNullException {
-        if (signature==null||"".equals(signature))
-        {
+    public static boolean encode(String[] str, boolean flag, String signature) throws SignatureCannotBeNullException {
+        if (signature == null||"".equals(signature)) {
             throw new SignatureCannotBeNullException("The signature mustn't be null or none string");
         }
-        return encode(str,flag).equals(signature);
+        return encode(str, flag).equals(signature);
     }
 
 

--- a/jodd-core/src/main/java/jodd/util/SignUtil.java
+++ b/jodd-core/src/main/java/jodd/util/SignUtil.java
@@ -27,12 +27,15 @@ package jodd.util;
 import java.security.MessageDigest;
 
 /**
- * The common sign util
+ * The common sign util.
  * @author zhangxin
  */
 public class SignUtil {
 
-    private static final char[] HEX_DIGITS = { '0', '1', '2', '3', '4', '5', '6', '7', '8', '9',
+    private SignUtil() {
+    }
+
+    private static final char[] HEX_DIGITS = {'0', '1', '2', '3', '4', '5', '6', '7', '8', '9',
             'a', 'b', 'c', 'd', 'e', 'f' };
 
     /**

--- a/jodd-core/src/main/java/jodd/util/SignUtil.java
+++ b/jodd-core/src/main/java/jodd/util/SignUtil.java
@@ -1,0 +1,75 @@
+// Copyright (c) 2003-present, Jodd Team (http://jodd.org)
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice,
+// this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+package jodd.util;
+
+import java.security.MessageDigest;
+
+/**
+ * The common sign util
+ * @author zhangxin
+ */
+public class SignUtil {
+
+    private static final char[] HEX_DIGITS = { '0', '1', '2', '3', '4', '5', '6', '7', '8', '9',
+            'a', 'b', 'c', 'd', 'e', 'f' };
+
+    /**
+     * According the encrypt type provided, encrypt the content.
+     *
+     * @param algorithm encrypt type, such as MD5,SHA1 and so on
+     * @param str the content will be encrypt
+     * @return String the result after encrypt
+     */
+    public static String encode(String algorithm, String str) {
+        if (str == null) {
+            return null;
+        }
+        try {
+            MessageDigest messageDigest = MessageDigest.getInstance(algorithm);
+            messageDigest.update(str.getBytes());
+            return getFormattedText(messageDigest.digest());
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+
+    }
+
+    /**
+     * The content into hex.
+     *
+     * @param bytes	the content(byte array) will be convert
+     * @return the convert result
+     */
+    private static String getFormattedText(byte[] bytes) {
+        int len = bytes.length;
+        StringBuilder buf = new StringBuilder(len * 2);
+        for (byte aByte : bytes) {
+            buf.append(HEX_DIGITS[(aByte >> 4) & 0x0f]);
+            buf.append(HEX_DIGITS[aByte & 0x0f]);
+        }
+        return buf.toString();
+    }
+
+}


### PR DESCRIPTION
## New behavior

Add two main function, md5 encrypt and sha1 encrypt，the sha1 encrypt support choose the content will be encrypt should be sorted in the dictionary order or not, and two function all provide compare with the signature provided function