### PR TITLE
LazyMap should preserve field order

### DIFF
--- a/jodd-json/src/main/java/jodd/json/LazyMap.java
+++ b/jodd-json/src/main/java/jodd/json/LazyMap.java
@@ -137,7 +137,7 @@ public class LazyMap extends AbstractMap {
 
 	private void buildIfNeeded() {
 		if (map == null) {
-			map = new HashMap<>();
+			map = new LinkedHashMap<>(size, 0.01f);
 
 			for (int index = 0; index < size; index++) {
 				Object value = values[index];


### PR DESCRIPTION
LazyMap is borrowed from Boon but is actually an old version that lacks a bug fix.
Even though JSON spec doesn't require to preserve field order, Javascript works this way (actually, IMHO, this is a flaw in the spec that will get fixed some day). Most parsers behave like Javascript too, including Jackson, Gson and Boon.

The change is just a matter of using a LinkedHashMap instead of a regular HashMap. I haven't noticed any performance degradation in my benchmarks.


<!--
You Are Awesome! Thank you for your contribution!
-->

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/oblac/jodd/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## Current behavior

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## New behavior?

<!-- Please describe the new behavior that PR introduces. -->
