### PR TITLE
JsonParsers should preserve field order

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,8 +33,8 @@ description = '''
 	simple, but not simpler.
 '''
 
-version = '4.2.0'
-//version = '4.1.6-' + date()
+//version = '4.2.0'
+version = '4.2.1-' + date()
 
 // --- properties -------------------------------------------------------------
 

--- a/jodd-json/src/main/java/jodd/json/JsonParserBase.java
+++ b/jodd-json/src/main/java/jodd/json/JsonParserBase.java
@@ -34,8 +34,8 @@ import jodd.typeconverter.TypeConverterManager;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -47,7 +47,7 @@ import java.util.function.Supplier;
  */
 public abstract class JsonParserBase {
 
-	protected static final Supplier<Map> HASMAP_SUPPLIER = HashMap::new;
+	protected static final Supplier<Map> HASMAP_SUPPLIER = LinkedHashMap::new;
 	protected static final Supplier<Map> LAZYMAP_SUPPLIER = LazyMap::new;
 
 	protected static final Supplier<List> ARRAYLIST_SUPPLIER = ArrayList::new;

--- a/jodd-json/src/main/java/jodd/json/LazyMap.java
+++ b/jodd-json/src/main/java/jodd/json/LazyMap.java
@@ -137,7 +137,7 @@ public class LazyMap extends AbstractMap {
 
 	private void buildIfNeeded() {
 		if (map == null) {
-			map = new HashMap<>();
+			map = new LinkedHashMap<>(size, 0.01f);
 
 			for (int index = 0; index < size; index++) {
 				Object value = values[index];
@@ -299,7 +299,5 @@ public class LazyMap extends AbstractMap {
 		public int size() {
 			return array.length;
 		}
-
 	}
-
 }

--- a/jodd-json/src/test/java/jodd/json/JsonParserTest.java
+++ b/jodd-json/src/test/java/jodd/json/JsonParserTest.java
@@ -44,8 +44,10 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.math.BigInteger;
 import java.net.URL;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 import java.util.zip.GZIPInputStream;
 
 import static jodd.util.ArraysUtil.ints;
@@ -895,4 +897,19 @@ class JsonParserTest {
 		});
 	}
 
+	@Test
+	void testLazyParserPreservesFieldOrder() {
+		String json = "{\"field1\":\"value1\", \"field2\":\"value2\", \"field3\":\"value3\", \"field4\":\"value4\"}";
+		JsonParsers.forEachParser(jsonParser -> {
+			Map<String, String> object = jsonParser.parse(json);
+
+			List<Map.Entry<String, String>> entries = object.entrySet().stream().collect(Collectors.toList());
+
+			assertEquals(4, entries.size());
+			assertEquals("field1", entries.get(0).getKey());
+			assertEquals("field2", entries.get(1).getKey());
+			assertEquals("field3", entries.get(2).getKey());
+			assertEquals("field4", entries.get(3).getKey());
+		});
+	}
 }


### PR DESCRIPTION
LazyMap is borrowed from Boon but is actually an old version that lacks a bug fix.

Even though JSON spec doesn't require to preserve field order, Javascript works this way (actually, IMHO, this is a flaw in the spec that will get fixed some day). Most parsers behave like Javascript too, including Jackson, Gson and Boon.

With this change, both eager and lazy parsers now use LinkedHashMap instead of regular HashMap.
I haven't noticed any performance degradation.