### PR TITLE
#599 Multi-Release in Manifest only for -jre9 artifact.

### DIFF
--- a/jodd-core/build.gradle
+++ b/jodd-core/build.gradle
@@ -12,6 +12,5 @@ dependencies {
 jar {
 	manifest {
 		instruction 'Import-Package', '*;resolution:=optional'
-		instruction 'Multi-Release', 'true'
 	}
 }


### PR DESCRIPTION
This patch resolves #599. `Multi-Release: true` attribute in Manifest should be set only in `jodd-core-jre9.jar` artifact which actually has `META-INF/versions` directory.