### PR TITLE
HTTP Proxy connection header fix.

### DIFF
--- a/jodd-http/src/main/java/jodd/http/net/SocketHttpConnectionProvider.java
+++ b/jodd-http/src/main/java/jodd/http/net/SocketHttpConnectionProvider.java
@@ -50,6 +50,7 @@ public class SocketHttpConnectionProvider implements HttpConnectionProvider {
 
 	protected ProxyInfo proxy = ProxyInfo.directProxy();
 	protected String secureEnabledProtocols = System.getProperty("https.protocols");
+	protected String sslProtocol = "SSL";
 
 	/**
 	 * Defines proxy to use for created sockets.
@@ -65,6 +66,21 @@ public class SocketHttpConnectionProvider implements HttpConnectionProvider {
 	 */
 	public void setSecuredProtocols(final String secureEnabledProtocols) {
 		this.secureEnabledProtocols = secureEnabledProtocols;
+	}
+
+	/**
+	 * Returns current ssl protocol used
+	 */
+	public String getSslProtocol() {
+		return sslProtocol;
+	}
+
+	/**
+	 * Sets default SSL protocol to use. One of "SSL", "TLSv1.2", "TLSv1.1", "TLSv1"
+	 */
+	public SocketHttpConnectionProvider setSslProtocol(String sslProtocol) {
+		this.sslProtocol = sslProtocol;
+		return this;
 	}
 
 	/**
@@ -215,7 +231,7 @@ public class SocketHttpConnectionProvider implements HttpConnectionProvider {
 	protected SSLSocketFactory getDefaultSSLSocketFactory(final boolean trustAllCertificates) throws IOException {
 		if (trustAllCertificates) {
 			try {
-				SSLContext sc = SSLContext.getInstance("SSL");
+				SSLContext sc = SSLContext.getInstance(sslProtocol);
 				sc.init(null, TrustManagers.TRUST_ALL_CERTS, new java.security.SecureRandom());
 				return sc.getSocketFactory();
 			}


### PR DESCRIPTION
HttpProxySocketFactory used to send CONNECT word 2 times.

<!--
You Are Awesome! Thank you for your contribution!
-->

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/oblac/jodd/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## Current behavior
At the moment HttpProxySocketFactory send wrong connect header to proxy.

## New behavior?
It's fixed now to generate proper connect header and code made more readable.