### PR TITLE
OpenJDK for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,13 @@ jdk:
   - oraclejdk8
   - oraclejdk9
 #  - oraclejdk10
+  - openjdk8
+  - openjdk9
 
 matrix:
   allow_failures:
     - jdk: oraclejdk9
+    - jdk: openjdk9
 
 before_install:
   # Disable services enabled by default


### PR DESCRIPTION
Hi,

oracle will change its support roadmap for java se versions -> http://www.oracle.com/technetwork/java/javase/eol-135779.html

Should jodd compile und run tests against openjdk(8/9) as well?

WDYT?

Bye