### PR TITLE
JsonParser#skipObject doesn't check if double quote char is actually escaped, close #637

### DIFF
--- a/jodd-json/src/main/java/jodd/json/JsonParser.java
+++ b/jodd-json/src/main/java/jodd/json/JsonParser.java
@@ -607,7 +607,7 @@ public class JsonParser extends JsonParserBase {
 			final char c = input[ndx];
 
 			if (insideString) {
-				if (c == '\"') {
+				if (c == '\"' && (ndx == 0 || input[ndx - 1] != '\\')) {
 					insideString = false;
 				}
 			}
@@ -867,7 +867,7 @@ public class JsonParser extends JsonParserBase {
 				// if string is 19 chars and longer, it can be over the limit
 				BigInteger bigInteger = new BigInteger(value);
 
-				if (isGreaterThenLong(bigInteger)) {
+				if (isGreaterThanLong(bigInteger)) {
 					return bigInteger;
 				}
 				longNumber = bigInteger.longValue();
@@ -883,7 +883,7 @@ public class JsonParser extends JsonParserBase {
 		return Long.valueOf(longNumber);
 	}
 
-	private static boolean isGreaterThenLong(final BigInteger bigInteger) {
+	private static boolean isGreaterThanLong(final BigInteger bigInteger) {
 		if (bigInteger.compareTo(MAX_LONG) > 0) {
 			return true;
 		}

--- a/jodd-json/src/test/java/jodd/json/JsonParserTest.java
+++ b/jodd-json/src/test/java/jodd/json/JsonParserTest.java
@@ -905,4 +905,19 @@ class JsonParserTest {
 			assertEquals("field4", entries.get(3).getKey());
 		});
 	}
+
+	@Test
+	void testLazyParserSupportEscapedDoubleQuotes() {
+		String json = "{ \"values\": [{ \"value\": \"foo\\\"bar\" }]}";
+
+		JsonParsers.forEachParser(jsonParser -> {
+			Map<String, Object> object = jsonParser.parse(json);
+
+			List<Map.Entry<String, Object>> entries = object.entrySet().stream().collect(Collectors.toList());
+
+			assertEquals(1, entries.size());
+			assertEquals("values", entries.get(0).getKey());
+			assertEquals("foo\"bar", ((List<Map<String, String>>) entries.get(0).getValue()).get(0).get("value"));
+		});
+	}
 }


### PR DESCRIPTION
Motivation:

Jodd crashes on some payloads that contain values with escaped double quotes char.

Modification:

In `JsonParser#skipObject` verify that double quote char isn't actually escaped when deciding we're no longer inside a String.

Result:

No more crash

Nore:

I also fixed a small typo: `s/isGreaterThenLong/isGreaterThanLong`