### PR TITLE
usage of annotation EnabledOnOs

### DIFF
--- a/jodd-core/src/test/java/jodd/io/PathUtilTest.java
+++ b/jodd-core/src/test/java/jodd/io/PathUtilTest.java
@@ -33,6 +33,8 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 
 import java.io.File;
 import java.io.IOException;
@@ -164,11 +166,10 @@ class PathUtilTest {
 		}
 
 		@Test
+		@EnabledOnOs({OS.WINDOWS})  // on windows host, test is successful. on linux host no io-exception is thrown
 		void testDeleteFileTree_not_successful() throws Exception {
 			assumeTrue(baseDir_Not_Successful.exists());
 			assumeTrue(locked_file.exists());
-
-			assumeTrue(SystemUtil.info().isWindows());   // on windows host, test is successful. on linux host no io-exception is thrown
 
 			// When you use FileLock, it is purely advisory—acquiring a lock on a file may not stop you from doing anything:
 			// reading, writing, and deleting a file may all be possible even when another process has acquired a lock.

--- a/jodd-core/src/test/java/jodd/util/CommandLineTest.java
+++ b/jodd-core/src/test/java/jodd/util/CommandLineTest.java
@@ -25,19 +25,18 @@
 
 package jodd.util;
 
-import jodd.system.SystemUtil;
 import jodd.util.ProcessRunner.ProcessResult;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 /**
  * Tests for {@link CommandLine}.
@@ -46,12 +45,8 @@ class CommandLineTest {
 
 	@Nested
 	@DisplayName("tests for CommandLine#run on windows hosts")
+	@EnabledOnOs(value = {OS.WINDOWS})
 	class Run_on_windows {
-
-		@BeforeEach
-		void beforeEach() {
-			assumeTrue(SystemUtil.info().isWindows(), "no windows host");
-		}
 
 		@Test
 		void testRun() throws Exception {
@@ -105,12 +100,8 @@ class CommandLineTest {
 
 	@Nested
 	@DisplayName("tests for CommandLine#run on linux hosts")
+	@EnabledOnOs(value = {OS.AIX, OS.LINUX, OS.MAC, OS.SOLARIS})
 	class Run_on_linux {
-
-		@BeforeEach
-		void beforeEach() {
-			assumeTrue(SystemUtil.info().isLinux(), "no linux host");
-		}
 
 		@Test
 		void testRun() throws Exception {

--- a/jodd-json/src/test/java/jodd/json/JsonSerializerTest.java
+++ b/jodd-json/src/test/java/jodd/json/JsonSerializerTest.java
@@ -35,6 +35,8 @@ import jodd.json.meta.JsonAnnotationManager;
 import jodd.json.meta.TypeData;
 import jodd.system.SystemUtil;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -52,7 +54,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 class JsonSerializerTest {
 
@@ -614,9 +615,8 @@ class JsonSerializerTest {
 	}
 
 	@Test
+	@EnabledOnOs(value = {OS.AIX, OS.LINUX, OS.MAC, OS.SOLARIS})
 	void testFiles_on_linux() {
-		assumeTrue(SystemUtil.info().isLinux() || SystemUtil.info().isMac(), "no linux host");
-
 		FileMan fileMan = new FileMan();
 		File userHome = new File(SystemUtil.info().getHomeDir());
 		fileMan.setFile(userHome);
@@ -627,9 +627,8 @@ class JsonSerializerTest {
 	}
 
 	@Test
+	@EnabledOnOs(value = {OS.WINDOWS})
 	void testFiles_on_windows() {
-		assumeTrue(SystemUtil.info().isWindows(), "no windows host");
-
 		FileMan fileMan = new FileMan();
 		File userHome = new File(SystemUtil.info().getHomeDir());
 		fileMan.setFile(userHome);

--- a/jodd-mail/src/test/java/jodd/mail/AttachmentStorageTest.java
+++ b/jodd-mail/src/test/java/jodd/mail/AttachmentStorageTest.java
@@ -28,17 +28,17 @@ package jodd.mail;
 import com.icegreen.greenmail.util.GreenMail;
 import com.icegreen.greenmail.util.ServerSetupTest;
 import jodd.io.FileUtil;
-import jodd.system.SystemUtil;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 
 import java.io.File;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
 class AttachmentStorageTest {
 
@@ -64,11 +64,11 @@ class AttachmentStorageTest {
 	}
 
 	@Test
+	@EnabledOnOs(value = {OS.AIX, OS.LINUX, OS.MAC, OS.SOLARIS})
 	void testAttachmentStorage() throws Exception {
 		// storing files with its message-id as file name fails on windows because value of the message-id consists of brackets
 		//		file names with brackets are not valid on window hosts
 		// see https://tools.ietf.org/html/rfc5322#section-3.6.4
-		assumeFalse(SystemUtil.info().isWindows(), "test will be skipped on windows hosts");
 
 		final SmtpServer smtpServer = MailServer.create()
 			.host(LOCALHOST)


### PR DESCRIPTION
Hi,

small refactoring of some test methods.

usage of annotation `EnabledOnOs `will be used instead of `assumeTrue|False` within test method.
PR is for issue #648 ;-)

Greetz