### PR TITLE
Fix java.version parsing under Java 11, close #654

### DIFF
--- a/jodd-core/src/main/java/jodd/system/JavaInfo.java
+++ b/jodd-core/src/main/java/jodd/system/JavaInfo.java
@@ -156,7 +156,7 @@ abstract class JavaInfo extends HostInfo {
 			return Integer.parseInt(JAVA_VERSION.substring(2, index));
 		} else {
 			final int index = JAVA_VERSION.indexOf('.');
-			return Integer.parseInt(JAVA_VERSION.substring(0, index));
+			return Integer.parseInt(index == -1 ? JAVA_VERSION : JAVA_VERSION.substring(0, index));
 		}
 	}
 


### PR DESCRIPTION
Motivation:

Initialization of several Jodd modules (verified for jodd-json and csselly) crash under Java 11 with a StringIndexOutOfBoundsException.

Modification:

Properly parse `java.version` System property when it doesn't contain a minor version.

Result:

Jodd works under Java 11.