### PR TITLE
Update FileUploadHeader.java

### DIFF
--- a/jodd-core/src/main/java/jodd/io/upload/FileUploadHeader.java
+++ b/jodd-core/src/main/java/jodd/io/upload/FileUploadHeader.java
@@ -108,7 +108,7 @@ public class FileUploadHeader {
 			return StringPool.EMPTY;
 		}
 		start += token.length();
-		return dataHeader.substring(start);
+		return dataHeader.substring(start).trim();
 	}
 
 	private String getContentDisposition(final String dataHeader) {


### PR DESCRIPTION
Maybe there's a space in front of contentType.
I get contentType " image/png" when I invoke jodd.io.upload.FileUploadHeader.getContentType.


<!--
You Are Awesome! Thank you for your contribution!
-->
