### PR TITLE
Fix JsonParser reset and trailing backslash handling, close #683  and close #684

### DIFF
--- a/jodd-json/src/main/java/jodd/json/JsonParser.java
+++ b/jodd-json/src/main/java/jodd/json/JsonParser.java
@@ -125,7 +125,7 @@ public class JsonParser extends JsonParserBase {
 	protected boolean looseMode = Defaults.loose;
 	protected Class rootType;
 	protected MapToBean mapToBean;
-	private boolean notFirstObject = false;
+	private boolean notFirstObject;
 
 	private final JsonAnnotationManager jsonAnnotationManager;
 
@@ -142,6 +142,7 @@ public class JsonParser extends JsonParserBase {
 		this.ndx = 0;
 		this.textLen = 0;
 		this.path = new Path();
+		this.notFirstObject = false;
 		if (useAltPaths) {
 			path.altPath = new Path();
 		}

--- a/jodd-json/src/main/java/jodd/json/JsonParser.java
+++ b/jodd-json/src/main/java/jodd/json/JsonParser.java
@@ -609,7 +609,7 @@ public class JsonParser extends JsonParserBase {
 
 	/**
 	 * Skips over complete object. It is not parsed, just skipped. It will be
-	 * parsed later, but oonly if required.
+	 * parsed later, but only if required.
 	 */
 	private void skipObject() {
 		int bracketCount = 1;
@@ -619,26 +619,32 @@ public class JsonParser extends JsonParserBase {
 			final char c = input[ndx];
 
 			if (insideString) {
-				if (c == '\"' && (ndx == 0 || input[ndx - 1] != '\\')) {
+				if (c == '\"' && notPrecededByEvenNumberOfBackslashes()) {
 					insideString = false;
 				}
-			}
-			else {
-				if (c == '\"') {
-					insideString = true;
-				}
-				if (c == '{') {
-					bracketCount++;
-				} else if (c == '}') {
-					bracketCount--;
-					if (bracketCount == 0) {
-						ndx++;
-						return;
-					}
+			} else if (c == '\"') {
+				insideString = true;
+			} else if (c == '{') {
+				bracketCount++;
+			} else if (c == '}') {
+				bracketCount--;
+				if (bracketCount == 0) {
+					ndx++;
+					return;
 				}
 			}
 			ndx++;
 		}
+	}
+
+	private boolean notPrecededByEvenNumberOfBackslashes() {
+		int pos = ndx;
+		int count = 0;
+		while (pos > 0 && input[pos - 1] == '\\') {
+			count++;
+			pos--;
+		}
+		return count  % 2 == 0;
 	}
 
 	// ---------------------------------------------------------------- string

--- a/jodd-json/src/test/java/jodd/json/JsonParserTest.java
+++ b/jodd-json/src/test/java/jodd/json/JsonParserTest.java
@@ -920,4 +920,19 @@ class JsonParserTest {
 			assertEquals("foo\"bar", ((List<Map<String, String>>) entries.get(0).getValue()).get(0).get("value"));
 		});
 	}
+
+	@Test
+	void testLazyParserSupportTrailingEscapedBackslash() {
+		String json = "{ \"foo\":{\"value\":\"\\\\\"} }";
+
+		JsonParsers.forEachParser(jsonParser -> {
+			Map<String, Object> object = jsonParser.parse(json);
+
+			List<Map.Entry<String, Object>> entries = object.entrySet().stream().collect(Collectors.toList());
+
+			assertEquals(1, entries.size());
+			assertEquals("foo", entries.get(0).getKey());
+			assertEquals("\\", ((Map<String, String>) entries.get(0).getValue()).get("value"));
+		});
+	}
 }


### PR DESCRIPTION
Motivation:

* JsonParser doesn't properly reset notFirstObject, which causes issues when recycling lazy parser instances
* JsonParser#skipObject agressively consider `"` preceded by `\` is escaped while this backslash itself could actually be escaped.

Modifications:

* reset `notFirstObject`
* fix skipObject so only `"` that are not preceded by pairs of `\` are considered as String termination

Result:

JsonParser lazy behavior fixed


<!--
You Are Awesome! Thank you for your contribution!
-->

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/oblac/jodd/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## Current behavior

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## New behavior?

<!-- Please describe the new behavior that PR introduces. -->
