### PR TITLE
Make the flags checking in ReceiveMailSession more correct

### DIFF
--- a/jodd-mail/src/main/java/jodd/mail/EmailUtil.java
+++ b/jodd-mail/src/main/java/jodd/mail/EmailUtil.java
@@ -29,15 +29,12 @@ import jodd.core.JoddCore;
 import jodd.util.CharUtil;
 import jodd.util.StringPool;
 
-import javax.mail.Authenticator;
-import javax.mail.MessagingException;
-import javax.mail.NoSuchProviderException;
-import javax.mail.Part;
-import javax.mail.Session;
-import javax.mail.Store;
+import javax.mail.*;
 import javax.mail.internet.MimeBodyPart;
 import javax.mail.internet.MimeUtility;
 import java.io.File;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.Properties;
 
 /**
@@ -176,6 +173,25 @@ public class EmailUtil {
 			throw new MailException(errMsg, nspex);
 		}
 		return new ReceiveMailSession(session, store, attachmentStorage);
+	}
+
+	/**
+	 * Check whether flags is a empty flags
+	 * @param flags a flags of message to check
+	 * @return whether the flags is empty
+	 */
+	public static boolean isEmptyFlags(Flags flags) {
+		if (flags == null) return true;
+		Flags.Flag[] systemFlags = flags.getSystemFlags();
+		if (systemFlags == null || systemFlags.length == 0) {
+			return true;
+		}
+		String[] userFlags = flags.getUserFlags();
+		if (userFlags == null || userFlags.length == 0) {
+			return true;
+		}
+
+		return false;
 	}
 
 }

--- a/jodd-mail/src/main/java/jodd/mail/EmailUtil.java
+++ b/jodd-mail/src/main/java/jodd/mail/EmailUtil.java
@@ -183,15 +183,15 @@ public class EmailUtil {
 	public static boolean isEmptyFlags(Flags flags) {
 		if (flags == null) return true;
 		Flags.Flag[] systemFlags = flags.getSystemFlags();
-		if (systemFlags == null || systemFlags.length == 0) {
-			return true;
+		if (systemFlags != null && systemFlags.length > 0) {
+			return false;
 		}
 		String[] userFlags = flags.getUserFlags();
-		if (userFlags == null || userFlags.length == 0) {
-			return true;
+		if (userFlags != null && userFlags.length > 0) {
+			return false;
 		}
 
-		return false;
+		return true;
 	}
 
 }

--- a/jodd-mail/src/main/java/jodd/mail/ReceiveMailSession.java
+++ b/jodd-mail/src/main/java/jodd/mail/ReceiveMailSession.java
@@ -338,17 +338,17 @@ public class ReceiveMailSession extends MailSession<Store> {
 				// we need to parse message BEFORE flags are set!
 				emails[i] = new ReceivedEmail(msg, envelope, attachmentStorage);
 
-				if (flagsToSet != null) {
+				if (!EmailUtil.isEmptyFlags(flagsToSet)) {
 					emails[i].flags(flagsToSet);
 					msg.setFlags(flagsToSet, true);
 				}
 
-				if (flagsToUnset != null) {
+				if (!EmailUtil.isEmptyFlags(flagsToUnset)) {
 					emails[i].flags().remove(flagsToUnset);
 					msg.setFlags(flagsToUnset, false);
 				}
 
-				if (flagsToSet == null && !emails[i].isSeen()) {
+				if (EmailUtil.isEmptyFlags(flagsToSet) && !emails[i].isSeen()) {
 					msg.setFlag(Flags.Flag.SEEN, false);
 				}
 			}
@@ -358,7 +358,7 @@ public class ReceiveMailSession extends MailSession<Store> {
 			}
 
 			// if messages were marked to be deleted, we need to expunge the folder
-			if (flagsToSet != null) {
+			if (!EmailUtil.isEmptyFlags(flagsToSet)) {
 				if (flagsToSet.contains(Flags.Flag.DELETED)) {
 					folder.expunge();
 				}

--- a/jodd-mail/src/test/java/jodd/mail/EmailUtilTest.java
+++ b/jodd-mail/src/test/java/jodd/mail/EmailUtilTest.java
@@ -30,10 +30,10 @@ import jodd.net.MimeTypes;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import javax.mail.Flags;
 import java.net.URL;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.*;
 
 class EmailUtilTest {
 
@@ -65,6 +65,23 @@ class EmailUtilTest {
 		contentType = "TEXT/PLAIN; charset=US-ASCII; name=example.eml";
 		assertEquals(MimeTypes.MIME_TEXT_PLAIN.toUpperCase(), EmailUtil.extractMimeType(contentType));
 		assertEquals(StringPool.US_ASCII, EmailUtil.extractEncoding(contentType));
+	}
+
+	@Test
+	void testIsEmptyFlags() {
+		Flags flags = new Flags();
+		flags.add(Flags.Flag.DELETED);
+		assertTrue(!EmailUtil.isEmptyFlags(flags));
+
+		flags = new Flags();
+		flags.add("userFlag");
+		assertTrue(!EmailUtil.isEmptyFlags(flags));
+
+		flags = new Flags();
+		assertTrue(EmailUtil.isEmptyFlags(flags));
+
+		flags = null;
+		assertTrue(EmailUtil.isEmptyFlags(flags));
 	}
 
 }


### PR DESCRIPTION
Motivation:
Since the ReceiverBuilder has two field:
```
private Flags flagsToSet = new Flags();
private Flags flagsToUnset = new Flags();
```
So when use the ReceiverBuilder#get to receive mail, the flagsToSet and flagsToUnset of ReceiveMailSession#receiveMessages()'s parameter are always non-null:
```
public ReceivedEmail[] get() {
		...
		return session.receiveMessages(filter, flagsToSet, flagsToUnset, envelopeOnly, messages -> {
			(...)
		});
	}
```
```
	ReceivedEmail[] receiveMessages(
			final EmailFilter filter,
			final Flags flagsToSet,
			final Flags flagsToUnset,
			final boolean envelope,
			final Consumer<Message[]> processedMessageConsumer) {
```

and there are some null checks below ：
```
if (flagsToSet != null) {
	emails[i].flags(flagsToSet);
	msg.setFlags(flagsToSet, true);
}

if (flagsToUnset != null) {
	emails[i].flags().remove(flagsToUnset);
	msg.setFlags(flagsToUnset, false);
}

if (flagsToSet == null && !emails[i].isSeen()) {
	msg.setFlag(Flags.Flag.SEEN, false);
}
```
when use ReceiverBuilder , these null checks seem to be useless, so I think it might need a more correct check for empty flags

Modification:
Add a check method in EmailUtil to verify that  systemFlags and userFlags is Empty or not