### PR TITLE
jodd-db/QueryParser: don't treat ::foo sequences as named parameters

### DIFF
--- a/jodd-db/src/main/java/jodd/db/DbQueryParser.java
+++ b/jodd-db/src/main/java/jodd/db/DbQueryParser.java
@@ -142,6 +142,19 @@ class DbQueryParser {
 			else if (c == '\'') {
 				inQuote = true;
 			}
+			else if (c == ':' && index + 1 < stringLength
+					&& sqlString.charAt(index + 1) == ':') {
+				// don't treat '::foo' sequence as named parameter; skip this
+				// chunk
+				int right = StringUtil.indexOfChars(sqlString,
+						SQL_SEPARATORS, index + 2);
+				if (right < 0) {
+					right = stringLength;
+				}
+				pureSql.append(sqlString.substring(index, right));
+				index = right;
+				continue;
+			}
 			else if (c == ':') {
 				int right = StringUtil.indexOfChars(sqlString, SQL_SEPARATORS, index + 1);
 				boolean batch = false;

--- a/jodd-db/src/test/java/jodd/db/DbQueryTest.java
+++ b/jodd-db/src/test/java/jodd/db/DbQueryTest.java
@@ -94,5 +94,17 @@ class DbQueryTest {
 		doTestDoubleNamedParam(dbp, "x", 1, 4);
 
 		assertTrue(dbp.prepared);
+
+		assertEquals("aa ::xxx aaa ::x aaa",
+				dbp.prepare("aa ::xxx aaa ::x aaa"));
+		assertEquals("aa bbb::xxx aaa ::", dbp.prepare("aa bbb::xxx aaa ::"));
+
+		assertEquals("aa ? aaa ::x", dbp.prepare("aa :xxx aaa ::x"));
+		doTestSingleNamedParam(dbp, "xxx", 1);
+
+		assertEquals("aa ? aaa ::", dbp.prepare("aa :xxx aaa ::"));
+		doTestSingleNamedParam(dbp, "xxx", 1);
+
+		assertTrue(dbp.prepared);
 	}
 }


### PR DESCRIPTION
Hello,
Small patch for DbQueryParser.

Postgresql use `value::type` syntax for type cast.	DbQueryParser ignore
double colon and create named parameters (some thing like `:?`).

Patch change DbQueryParser::parseSql - chunks started with `::` are copied
to final sql without modification.

Tests updated.


<!--
You Are Awesome! Thank you for your contribution!
-->

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/oblac/jodd/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## Current behavior

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## New behavior?

<!-- Please describe the new behavior that PR introduces. -->
