### PR TITLE
htmlstampler: fix encoding url for `data:` content.

### DIFF
--- a/jodd-htmlstapler/src/main/java/jodd/htmlstapler/HtmlStaplerBundlesManager.java
+++ b/jodd-htmlstapler/src/main/java/jodd/htmlstapler/HtmlStaplerBundlesManager.java
@@ -597,7 +597,7 @@ public class HtmlStaplerBundlesManager {
 			final String matchedUrl = StringUtil.removeChars(matcher.group(1), "'\"");
 
 			final String url;
-			if (matchedUrl.startsWith("https://") || matchedUrl.startsWith("http://") || matchedUrl.startsWith("data://")) {
+			if (matchedUrl.startsWith("https://") || matchedUrl.startsWith("http://") || matchedUrl.startsWith("data:")) {
 				url = "url('" + matchedUrl + "')";
 			}
 			else {

--- a/jodd-htmlstapler/src/test/java/jodd/htmlstapler/HtmlStaplerBundlesManagerTest.java
+++ b/jodd-htmlstapler/src/test/java/jodd/htmlstapler/HtmlStaplerBundlesManagerTest.java
@@ -68,5 +68,11 @@ class HtmlStaplerBundlesManagerTest {
 
 		fixedCss = hsbm.fixCssRelativeUrls("@import url('https://fonts.googleapis.com/css?family=Roboto:300,400,500,700');", "/");
 		assertEquals("@import url('https://fonts.googleapis.com/css?family=Roboto:300,400,500,700');", fixedCss);
+
+		fixedCss = hsbm.fixCssRelativeUrls("background-image:url(data:image/png;base64,iVBORw0KGgoAAAANSUhE);", "/");
+		assertEquals("background-image:url('data:image/png;base64,iVBORw0KGgoAAAANSUhE');", fixedCss);
+
+		fixedCss = hsbm.fixCssRelativeUrls("background-image:url('data:image/png;base64,iVBORw0KGgoAAAANSUhE');", "/");
+		assertEquals("background-image:url('data:image/png;base64,iVBORw0KGgoAAAANSUhE');", fixedCss);
 	}
 }


### PR DESCRIPTION
Hi,
Related o to  #691; I didn't notice it earlier..

HtmlStaplerBundlesManager has small bug - inline in url content not starts
with `data://` but only `data:`, ie:
background-image:url('data:image/png;base64,iVBORw0KGgoAAAANSUhE...');

This patch only replace `data://` with  `data:`.
Tests updated.


<!--
You Are Awesome! Thank you for your contribution!
-->

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/oblac/jodd/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

