### PR TITLE
Fix LazyMap#values returning Suppliers

### DIFF
--- a/jodd-json/src/main/java/jodd/json/LazyMap.java
+++ b/jodd-json/src/main/java/jodd/json/LazyMap.java
@@ -17,11 +17,9 @@ package jodd.json;
 
 import java.lang.reflect.Array;
 import java.util.AbstractMap;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Supplier;
@@ -39,7 +37,7 @@ public class LazyMap extends AbstractMap {
 	private Object[] keys;
 	private Object[] values;
 
-	public LazyMap() {
+	LazyMap() {
 		keys = new Object[5];
 		values = new Object[5];
 	}
@@ -188,7 +186,7 @@ public class LazyMap extends AbstractMap {
 
 	// ---------------------------------------------------------------- utils
 
-	private static <V> Set<V> set(final int size, final V... array) {
+	private static <V> Set<V> set(final int size, final V[] array) {
 		int index = 0;
 		final Set<V> set = new HashSet<>();
 
@@ -203,17 +201,9 @@ public class LazyMap extends AbstractMap {
 	}
 
 	private static <V> V[] grow(final V[] array) {
-		final Object newArray = Array.newInstance(array.getClass().getComponentType(), array.length * 2);
+		@SuppressWarnings("unchecked")
+		final V[] newArray = (V[]) Array.newInstance(array.getClass().getComponentType(), array.length * 2);
 		System.arraycopy(array, 0, newArray, 0, array.length);
-		return (V[]) newArray;
-	}
-
-	private static <V> List<V> list(final V... array) {
-		final int length = array.length;
-		final List<V> list = new ArrayList<>();
-		for (int index = 0; index < length; index++) {
-			list.add((V) Array.get(array, index));
-		}
-		return list;
+		return newArray;
 	}
 }

--- a/jodd-json/src/main/java/jodd/json/LazyMap.java
+++ b/jodd-json/src/main/java/jodd/json/LazyMap.java
@@ -18,7 +18,6 @@ package jodd.json;
 import java.lang.reflect.Array;
 import java.util.AbstractMap;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
@@ -160,8 +159,8 @@ public class LazyMap extends AbstractMap {
 
 	@Override
 	public Collection values() {
-		return map == null ? Arrays.asList(values) : map.values();
-
+		buildIfNeeded();
+		return map.values();
 	}
 
 	@Override

--- a/jodd-json/src/test/java/jodd/json/JsonParserTest.java
+++ b/jodd-json/src/test/java/jodd/json/JsonParserTest.java
@@ -935,4 +935,18 @@ class JsonParserTest {
 			assertEquals("\\", ((Map<String, String>) entries.get(0).getValue()).get("value"));
 		});
 	}
+
+	@Test
+	void testLazyParserValuesDoesntReturnSuppliers() {
+		String json = "{ \"foo\":{\"bar\":\"value\"} }";
+
+		JsonParsers.forEachParser(jsonParser -> {
+			Map<String, Object> object = jsonParser.parse(json);
+
+			object.values().forEach(value -> {
+				Map<String, String> inner = (Map<String, String>) value;
+				assertEquals("value", inner.values().iterator().next());
+			});
+		});
+	}
 }


### PR DESCRIPTION
Motivation:

LazyMap#values shoudn't return Suppliers but real values.

Modification:

Have LazyMap#values always build the actual Map instead of returning values that might be Suppliers (ObjectParsers).

Result:

LazyMap#values returns actual values