### PR TITLE
dboom domain class with char :  DbOom.get().entities().update(entity) -> ClassCastException

### DIFF
--- a/jodd-db/src/main/java/jodd/db/oom/sqlgen/chunks/SqlChunk.java
+++ b/jodd-db/src/main/java/jodd/db/oom/sqlgen/chunks/SqlChunk.java
@@ -257,9 +257,16 @@ public abstract class SqlChunk {
 
 		// special case for primitives
 		if (dec.getPropertyType().isPrimitive()) {
-			final double d = ((Number) value).doubleValue();
-			if (d == 0) {
-				return true;
+			if (char.class == dec.getPropertyType()) {
+				final Character c = ((Character) value);
+				if ('\u0000' == c.charValue()) {
+					return true;
+				}
+			} else {
+				final double d = ((Number) value).doubleValue();
+				if (d == 0) {
+					return true;
+				}
 			}
 		}
 

--- a/jodd-db/src/test/java/jodd/db/fixtures/DbHsqldbTestCase.java
+++ b/jodd-db/src/test/java/jodd/db/fixtures/DbHsqldbTestCase.java
@@ -46,6 +46,8 @@ public abstract class DbHsqldbTestCase extends DbTestBase {
 	protected void initDb(final DbSession session) {
 		executeUpdate(session, "drop table BOY if exists");
 		executeUpdate(session, "drop table GIRL if exists");
+		executeUpdate(session, "drop table ENTITY if exists");
+		executeUpdate(session, "drop table ENTITY_CHAR if exists");
 
 		String sql = "create table GIRL (" +
 				"ID			integer		not null," +
@@ -64,13 +66,20 @@ public abstract class DbHsqldbTestCase extends DbTestBase {
 				')';
 		executeUpdate(session, sql);
 
-		executeUpdate(session, "drop table ENTITY if exists");
 		sql = "create table ENTITY (" +
 			"ID			integer	not null," +
 			"NAME	varchar(20)	null," +
 			"VALUE	double  	null," +
 			"primary key (ID)" +
 			')';
+		executeUpdate(session, sql);
+
+		sql = "create table ENTITY_CHAR (" +
+				"ID			integer	not null," +
+				"NAME	varchar(20)	null," +
+				"VALUE	varchar(1) 	null," +
+				"primary key (ID)" +
+				')';
 		executeUpdate(session, sql);
 	}
 

--- a/jodd-db/src/test/java/jodd/db/oom/DbOomPrimitiveCharTest.java
+++ b/jodd-db/src/test/java/jodd/db/oom/DbOomPrimitiveCharTest.java
@@ -1,0 +1,115 @@
+// Copyright (c) 2003-present, Jodd Team (http://jodd.org)
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice,
+// this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+package jodd.db.oom;
+
+import jodd.db.DbOom;
+import jodd.db.DbSession;
+import jodd.db.DbThreadSession;
+import jodd.db.QueryMapper;
+import jodd.db.fixtures.DbHsqldbTestCase;
+import jodd.db.oom.meta.DbColumn;
+import jodd.db.oom.meta.DbId;
+import jodd.db.oom.meta.DbTable;
+import jodd.db.type.StringSqlType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+class DbOomPrimitiveCharTest extends DbHsqldbTestCase {
+
+	@Override
+	@BeforeEach
+	protected void setUp() throws Exception {
+		super.setUp();
+
+		DbEntityManager dbEntityManager = DbOom.get().entityManager();
+
+		dbEntityManager.registerEntity(Entity.class);
+	}
+
+	@Test
+	void testOrm() {
+		try (final DbSession session = new DbThreadSession(cp)) {
+			final Entity toInsert = new Entity(1, "Jodd", 'g');
+			assertEquals(1, dbOom.entities().insert(toInsert).query().autoClose().executeUpdate());
+			final Entity afterInsert = loadEntityWithId1();
+			assertNotNull(afterInsert);
+			assertEquals('g', afterInsert.value);
+			// now update given entity
+			final Entity toUpdated = new Entity(1, "makes fun", 'h');
+			assertEquals(1, dbOom.entities().update(toUpdated).query().autoClose().executeUpdate());
+			final Entity afterUpdate = loadEntityWithId1();
+			assertNotNull(afterUpdate);
+			assertEquals("makes fun", afterUpdate.name);
+			assertEquals('h', afterUpdate.value);
+		}
+	}
+
+	Entity loadEntityWithId1() {
+		DbOomQuery q = DbOomQuery.query("select * from Entity_CHAR where id=1");
+		Entity entity = q.find(new QueryMapper<Entity>() {
+			@Override
+			public Entity process(ResultSet resultSet) throws SQLException {
+				Entity _entity = new Entity();
+				_entity.id = resultSet.getInt("ID");
+				_entity.name = resultSet.getString("NAME");
+				_entity.value = resultSet.getString("VALUE").charAt(0);
+				return _entity;
+			}
+		});
+
+		return entity;
+	}
+
+
+	@DbTable (value = "ENTITY_CHAR")
+	public static class Entity {
+
+		Entity() {
+		}
+
+		public Entity(long id, String name, char value) {
+			this.id = id;
+			this.name = name;
+			this.value = value;
+		}
+
+		@DbId
+		long id;
+
+		@DbColumn
+		String name;
+
+		@DbColumn (sqlType = StringSqlType.class)
+		char value;
+	}
+
+}


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/oblac/jodd/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## Current behavior

given dboom model class with char (primitive) class var (similar to #695)
following exception willl be thrown:
```
java.lang.ClassCastException: java.lang.Character cannot be cast to java.lang.Number

	at jodd.db.oom.sqlgen.chunks.SqlChunk.isEmptyColumnValue(SqlChunk.java:260)
	at jodd.db.oom.sqlgen.chunks.UpdateSetChunk.process(UpdateSetChunk.java:81)
	at jodd.db.oom.sqlgen.DbSqlBuilder.generateQuery(DbSqlBuilder.java:233)
	at jodd.db.oom.DbOomQuery.<init>(DbOomQuery.java:122)
	at jodd.db.oom.sqlgen.DbSqlBuilder.query(DbSqlBuilder.java:422)
	at jodd.db.oom.DbOomPrimitveCharTest.testOrm(DbOomPrimitveCharTest.java:69)
```

## New behavior?

no exception will be thrown ;-)
and handling due to default value  for char is added, too.


WDYT?


Greetz
