### PR TITLE
Fix closeFolderIfOpened

### DIFF
--- a/jodd-mail/src/main/java/jodd/mail/ReceiveMailSession.java
+++ b/jodd-mail/src/main/java/jodd/mail/ReceiveMailSession.java
@@ -391,7 +391,7 @@ public class ReceiveMailSession extends MailSession<Store> {
 	 * Closes folder if opened and expunge deleted messages.
 	 */
 	protected void closeFolderIfOpened(final Folder folder) {
-		if (folder != null) {
+		if (folder != null && folder.isOpen()) {
 			try {
 				folder.close(true);
 			} catch (final MessagingException ignore) {


### PR DESCRIPTION
## Current behavior
An IllegalStateException will be thrown if the folder is not already open

## New behavior?
Only attempt to close the folder if it is open
