### PR TITLE
Change method name 'create' to 'createJsonParser', 'fill' to 'readBytes'

### DIFF
--- a/jodd-http/src/main/java/jodd/http/net/Socks5ProxySocketFactory.java
+++ b/jodd-http/src/main/java/jodd/http/net/Socks5ProxySocketFactory.java
@@ -102,7 +102,7 @@ public class Socks5ProxySocketFactory extends SocketFactory {
 
 			// 2) RESPONSE
 			// in.read(buf, 0, 2);
-			fill(in, buf, 2);
+			readBytes(in, buf, 2);
 
 			boolean check = false;
 			switch ((buf[1]) & 0xff) {
@@ -130,7 +130,7 @@ public class Socks5ProxySocketFactory extends SocketFactory {
 
 					// 4) RESPONSE, VERIFIED
 					// in.read(buf, 0, 2);
-					fill(in, buf, 2);
+					readBytes(in, buf, 2);
 					if (buf[1] == 0) {
 						check = true;
 					}
@@ -168,7 +168,7 @@ public class Socks5ProxySocketFactory extends SocketFactory {
 			// 6) RESPONSE
 
 			// in.read(buf, 0, 4);
-			fill(in, buf, 4);
+			readBytes(in, buf, 4);
 
 			if (buf[1] != 0) {
 				try {
@@ -181,17 +181,17 @@ public class Socks5ProxySocketFactory extends SocketFactory {
 			switch (buf[3] & 0xff) {
 				case 1:
 					// in.read(buf, 0, 6);
-					fill(in, buf, 6);
+					readBytes(in, buf, 6);
 					break;
 				case 3:
 					// in.read(buf, 0, 1);
-					fill(in, buf, 1);
+					readBytes(in, buf, 1);
 					// in.read(buf, 0, buf[0]+2);
-					fill(in, buf, (buf[0] & 0xff) + 2);
+					readBytes(in, buf, (buf[0] & 0xff) + 2);
 					break;
 				case 4:
 					// in.read(buf, 0, 18);
-					fill(in, buf, 18);
+					readBytes(in, buf, 18);
 					break;
 				default:
 			}
@@ -205,7 +205,7 @@ public class Socks5ProxySocketFactory extends SocketFactory {
 		}
 	}
 
-	private void fill(final InputStream in, final byte[] buf, final int len) throws IOException {
+	private void readBytes(final InputStream in, final byte[] buf, final int len) throws IOException {
 		int s = 0;
 		while (s < len) {
 			int i = in.read(buf, s, len - s);

--- a/jodd-joy/src/main/java/jodd/joy/auth/simtok/SimTokCoder.java
+++ b/jodd-joy/src/main/java/jodd/joy/auth/simtok/SimTokCoder.java
@@ -71,6 +71,6 @@ public class SimTokCoder {
 		}
 
 		final String p2Decoded = Base64.decodeToString(p2);
-		return JsonParser.create().parse(p2Decoded, SimTok.class);
+		return JsonParser.createJsonParser().parse(p2Decoded, SimTok.class);
 	}
 }

--- a/jodd-joy/src/testInt/java/jodd/joy/auth/simtok/SimTokTest.java
+++ b/jodd-joy/src/testInt/java/jodd/joy/auth/simtok/SimTokTest.java
@@ -34,7 +34,7 @@ class SimTokTest {
 
 	@Test
 	void testSimTok() {
-		SimTok simTok = SimTok.create().setName("jodd").setUid("173").setDuration(1000);
+		SimTok simTok = SimTok.createJsonParser().setName("jodd").setUid("173").setDuration(1000);
 
 		String json = new SimTokCoder().encode(simTok);
 

--- a/jodd-joy/src/testInt/java/jodd/joy/fixtures/MyUserAuth.java
+++ b/jodd-joy/src/testInt/java/jodd/joy/fixtures/MyUserAuth.java
@@ -43,7 +43,7 @@ public class MyUserAuth implements UserAuth<SimTok> {
 		if (!credentials.equals(principal + "!")) {
 			return null;
 		}
-		return SimTok.create().setName(principal).setUid("1");
+		return SimTok.createJsonParser().setName(principal).setUid("1");
 	}
 
 	@Override

--- a/jodd-json/src/main/java/jodd/json/JsonParser.java
+++ b/jodd-json/src/main/java/jodd/json/JsonParser.java
@@ -92,7 +92,7 @@ public class JsonParser extends JsonParserBase {
 	/**
 	 * Static ctor.
 	 */
-	public static JsonParser create() {
+	public static JsonParser createJsonParser() {
 		return new JsonParser();
 	}
 

--- a/jodd-json/src/test/java/jodd/json/FieldsBooleanTest.java
+++ b/jodd-json/src/test/java/jodd/json/FieldsBooleanTest.java
@@ -36,7 +36,7 @@ class FieldsBooleanTest {
 	void testBooleanField() {
 		Active active = new Active();
 
-		String json = JsonSerializer.create().serialize(active);
+		String json = JsonSerializer.createJsonParser().serialize(active);
 
 		System.out.println(json);
 

--- a/jodd-json/src/test/java/jodd/json/JsonArrayTest.java
+++ b/jodd-json/src/test/java/jodd/json/JsonArrayTest.java
@@ -690,7 +690,7 @@ class JsonArrayTest {
 		jsonArray.add(new JsonArray().add("foo").add(123));
 		String strBytes = Base64.getEncoder().encodeToString(bytes);
 		String expected = "[\"foo\",123,1234,1.23,2.34,true,\"" + strBytes + "\",null,{\"foo\":\"bar\"},[\"foo\",123]]";
-		String json = JsonSerializer.create().serialize(jsonArray);
+		String json = JsonSerializer.createJsonParser().serialize(jsonArray);
 		assertEquals(expected, json);
 	}
 
@@ -720,7 +720,7 @@ class JsonArrayTest {
 	@Test
 	void testToString() {
 		jsonArray.add("foo").add(123);
-		assertEquals(JsonSerializer.create().serialize(jsonArray), jsonArray.toString());
+		assertEquals(JsonSerializer.createJsonParser().serialize(jsonArray), jsonArray.toString());
 	}
 
 	@Test

--- a/jodd-json/src/test/java/jodd/json/JsonObjectTest.java
+++ b/jodd-json/src/test/java/jodd/json/JsonObjectTest.java
@@ -1025,8 +1025,8 @@ class JsonObjectTest {
 	@Test
 	void testMergeInDepth0() {
 		{
-			JsonObject obj1 = JsonParser.create().parseAsJsonObject("{ \"foo\": { \"bar\": \"flurb\" }}");
-			JsonObject obj2 = JsonParser.create().parseAsJsonObject("{ \"foo\": { \"bar\": \"eek\" }}");
+			JsonObject obj1 = JsonParser.createJsonParser().parseAsJsonObject("{ \"foo\": { \"bar\": \"flurb\" }}");
+			JsonObject obj2 = JsonParser.createJsonParser().parseAsJsonObject("{ \"foo\": { \"bar\": \"eek\" }}");
 			obj1.mergeIn(obj2, 0);
 			assertEquals(1, obj1.size());
 			assertEquals(1, obj1.getJsonObject("foo").size());
@@ -1057,8 +1057,8 @@ class JsonObjectTest {
 	@Test
 	void testMergeInDepth1() {
 		{
-			JsonObject obj1 = JsonParser.create().parseAsJsonObject("{ \"foo\": \"bar\", \"flurb\": { \"eek\": \"foo\", \"bar\": \"flurb\"}}");
-			JsonObject obj2 = JsonParser.create().parseAsJsonObject("{ \"flurb\": { \"bar\": \"flurb1\" }}");
+			JsonObject obj1 = JsonParser.createJsonParser().parseAsJsonObject("{ \"foo\": \"bar\", \"flurb\": { \"eek\": \"foo\", \"bar\": \"flurb\"}}");
+			JsonObject obj2 = JsonParser.createJsonParser().parseAsJsonObject("{ \"flurb\": { \"bar\": \"flurb1\" }}");
 			obj1.mergeIn(obj2, 1);
 			assertEquals(2, obj1.size());
 			assertEquals(1, obj1.getJsonObject("flurb").size());
@@ -1077,8 +1077,8 @@ class JsonObjectTest {
 	@Test
 	void testMergeInDepth2() {
 		{
-			JsonObject obj1 = new JsonObject(JsonParser.create().parse("{ \"foo\": \"bar\", \"flurb\": { \"eek\": \"foo\", \"bar\": \"flurb\"}}"));
-			JsonObject obj2 = new JsonObject(JsonParser.create().parse("{ \"flurb\": { \"bar\": \"flurb1\" }}"));
+			JsonObject obj1 = new JsonObject(JsonParser.createJsonParser().parse("{ \"foo\": \"bar\", \"flurb\": { \"eek\": \"foo\", \"bar\": \"flurb\"}}"));
+			JsonObject obj2 = new JsonObject(JsonParser.createJsonParser().parse("{ \"flurb\": { \"bar\": \"flurb1\" }}"));
 			obj1.mergeIn(obj2, 2);
 			assertEquals(2, obj1.size());
 			assertEquals(2, obj1.getJsonObject("flurb").size());
@@ -1114,7 +1114,7 @@ class JsonObjectTest {
 			jsonObject.put("myobj", new JsonObject().put("foo", "bar"));
 			jsonObject.put("myarr", new JsonArray().add("foo").add(123));
 
-			String json = JsonSerializer.create().serialize(jsonObject);
+			String json = JsonSerializer.createJsonParser().serialize(jsonObject);
 
 			JsonObject expectedParsedJsonObject = jsonParser.parseAsJsonObject(json);
 
@@ -1153,7 +1153,7 @@ class JsonObjectTest {
 		JsonObject jsonObject = new JsonObject();
 
 		jsonObject.put("foo", "bar");
-		assertEquals(JsonSerializer.create().serialize(jsonObject), jsonObject.toString());
+		assertEquals(JsonSerializer.createJsonParser().serialize(jsonObject), jsonObject.toString());
 	}
 
 	@Test

--- a/jodd-json/src/test/java/jodd/json/JsonParserTypeTest.java
+++ b/jodd-json/src/test/java/jodd/json/JsonParserTypeTest.java
@@ -44,11 +44,11 @@ class JsonParserTypeTest {
 			return PAGER;
 		});
 
-		Phone phone = JsonParser.create().parse("{\"number\": 123, \"type\": 0}", Phone.class);
+		Phone phone = JsonParser.createJsonParser().parse("{\"number\": 123, \"type\": 0}", Phone.class);
 
 		assertEquals(HOME, phone.getType());
 
-		phone = JsonParser.create().parse("{\"number\": 123, \"type\": \"0\"}", Phone.class);
+		phone = JsonParser.createJsonParser().parse("{\"number\": 123, \"type\": \"0\"}", Phone.class);
 
 		assertEquals(PAGER, phone.getType());
 	}

--- a/jodd-json/src/test/java/jodd/json/JsonSerializerTest.java
+++ b/jodd-json/src/test/java/jodd/json/JsonSerializerTest.java
@@ -621,7 +621,7 @@ class JsonSerializerTest {
 		File userHome = new File(SystemUtil.info().getHomeDir());
 		fileMan.setFile(userHome);
 
-		String json = JsonSerializer.create().serialize(fileMan);
+		String json = JsonSerializer.createJsonParser().serialize(fileMan);
 
 		assertTrue(json.contains(SystemUtil.info().getHomeDir()));
 	}
@@ -633,7 +633,7 @@ class JsonSerializerTest {
 		File userHome = new File(SystemUtil.info().getHomeDir());
 		fileMan.setFile(userHome);
 
-		final String json = JsonSerializer.create().serialize(fileMan);
+		final String json = JsonSerializer.createJsonParser().serialize(fileMan);
 		// C:\Users\xxxx will be user home on windows hsost;  char '\' is escpaed in json therefore the execution of "String#replace"
 		final String userhome_escpaed = SystemUtil.info().getHomeDir().replace("\\", "\\\\");
 		assertTrue(json.contains(userhome_escpaed));
@@ -652,7 +652,7 @@ class JsonSerializerTest {
 		hitList.getNumbers().add(22);
 
 		String json = JsonSerializer
-			.create()
+			.createJsonParser()
 			.deep(true)
 			.serialize(hitList);
 
@@ -670,7 +670,7 @@ class JsonSerializerTest {
 			String path = "/foo/bar";
 
 			String json = JsonSerializer
-				.create()
+				.createJsonParser()
 				.strictStringEncoding(true)
 				.serialize(path);
 
@@ -685,16 +685,16 @@ class JsonSerializerTest {
 	@Test
 	void testClassMetaData() {
 		String json = JsonSerializer
-			.create()
+			.createJsonParser()
 			.withClassMetadata(true)
 			.serialize(new Foo());
 
 		assertTrue(json.contains("\"__class\":\"" + Foo.class.getName() + "\""));
 
-		json = JsonSerializer.create().withClassMetadata(false).serialize(123);
+		json = JsonSerializer.createJsonParser().withClassMetadata(false).serialize(123);
 		assertEquals("123", json);
 
-		json = JsonSerializer.create().withClassMetadata(true).serialize(123);
+		json = JsonSerializer.createJsonParser().withClassMetadata(true).serialize(123);
 		assertEquals("123", json);
 	}
 
@@ -703,11 +703,11 @@ class JsonSerializerTest {
 		UUID uuid = UUID.randomUUID();
 
 		String json = JsonSerializer
-			.create()
+			.createJsonParser()
 			.serialize(uuid);
 
 		UUID uuid2 = JsonParser
-			.create()
+			.createJsonParser()
 			.parse(json, UUID.class);
 
 		assertEquals(uuid, uuid2);

--- a/jodd-json/src/test/java/jodd/json/JsonStrictTest.java
+++ b/jodd-json/src/test/java/jodd/json/JsonStrictTest.java
@@ -48,16 +48,16 @@ public class JsonStrictTest {
 	@Test
 	void testStrictParsing() {
 		Assertions.assertThrows(JsonException.class, () -> {
-			JsonParser.create().parse("{\"id\":\"\"}", Ider.class);
+			JsonParser.createJsonParser().parse("{\"id\":\"\"}", Ider.class);
 		});
 	}
 
 	@Test
 	void testNonStrictParsing() {
-		Ider ider = JsonParser.create().parse("{\"id\":\"1\"}", Ider.class);
+		Ider ider = JsonParser.createJsonParser().parse("{\"id\":\"1\"}", Ider.class);
 		assertEquals(1, ider.getId().intValue());
 
-		ider = JsonParser.create().strictTypes(false).parse("{\"id\":\"\"}", Ider.class);
+		ider = JsonParser.createJsonParser().strictTypes(false).parse("{\"id\":\"\"}", Ider.class);
 		assertNull(ider.getId());
 	}
 }

--- a/jodd-json/src/test/java/jodd/json/NansInfTest.java
+++ b/jodd-json/src/test/java/jodd/json/NansInfTest.java
@@ -36,7 +36,7 @@ public class NansInfTest {
 	@Test
 	public void testDouble_NaN() {
 		JsonParsers.forEachParser(jsonParser -> {
-			String json = JsonSerializer.create().serialize(Double.NaN);
+			String json = JsonSerializer.createJsonParser().serialize(Double.NaN);
 
 			assertEquals("\"NaN\"", json);
 
@@ -49,7 +49,7 @@ public class NansInfTest {
 	@Test
 	public void testFloat_NaN() {
 		JsonParsers.forEachParser(jsonParser -> {
-			String json = JsonSerializer.create().serialize(Float.NaN);
+			String json = JsonSerializer.createJsonParser().serialize(Float.NaN);
 
 			assertEquals("\"NaN\"", json);
 
@@ -62,7 +62,7 @@ public class NansInfTest {
 	@Test
 	public void testDouble_Infinity() {
 		JsonParsers.forEachParser(jsonParser -> {
-			String json = JsonSerializer.create().serialize(Double.POSITIVE_INFINITY);
+			String json = JsonSerializer.createJsonParser().serialize(Double.POSITIVE_INFINITY);
 
 			assertEquals("\"+Infinity\"", json);
 
@@ -70,7 +70,7 @@ public class NansInfTest {
 
 			assertEquals(Double.POSITIVE_INFINITY, d.doubleValue());
 
-			json = JsonSerializer.create().serialize(Double.NEGATIVE_INFINITY);
+			json = JsonSerializer.createJsonParser().serialize(Double.NEGATIVE_INFINITY);
 
 			assertEquals("\"-Infinity\"", json);
 
@@ -83,7 +83,7 @@ public class NansInfTest {
 	@Test
 	public void testFloat_Infinity() {
 		JsonParsers.forEachParser(jsonParser -> {
-			String json = JsonSerializer.create().serialize(Float.POSITIVE_INFINITY);
+			String json = JsonSerializer.createJsonParser().serialize(Float.POSITIVE_INFINITY);
 
 			assertEquals("\"+Infinity\"", json);
 
@@ -91,7 +91,7 @@ public class NansInfTest {
 
 			assertEquals(Float.POSITIVE_INFINITY, d.floatValue());
 
-			json = JsonSerializer.create().serialize(Float.NEGATIVE_INFINITY);
+			json = JsonSerializer.createJsonParser().serialize(Float.NEGATIVE_INFINITY);
 
 			assertEquals("\"-Infinity\"", json);
 

--- a/jodd-json/src/test/java/jodd/json/fixtures/JsonParsers.java
+++ b/jodd-json/src/test/java/jodd/json/fixtures/JsonParsers.java
@@ -36,8 +36,8 @@ public class JsonParsers {
 			final JsonParser jsonParser;
 
 			switch (i) {
-				case 0: jsonParser = JsonParser.create(); break;
-				case 1: jsonParser = JsonParser.create().lazy(true); break;
+				case 0: jsonParser = JsonParser.createJsonParser(); break;
+				case 1: jsonParser = JsonParser.createJsonParser().lazy(true); break;
 				default:
 					throw new IllegalArgumentException("Not good.");
 			}

--- a/jodd-madvoc/src/main/java/jodd/madvoc/result/JsonActionResult.java
+++ b/jodd-madvoc/src/main/java/jodd/madvoc/result/JsonActionResult.java
@@ -69,7 +69,7 @@ public class JsonActionResult implements ActionResult {
 			statusMessage = jsonResult.message();
 		}
 		else {
-			json = JsonSerializer.create().deep(true).serialize(resultValue);
+			json = JsonSerializer.createJsonParser().deep(true).serialize(resultValue);
 			status = 200;
 			statusMessage = "OK";
 		}

--- a/jodd-madvoc/src/main/java/jodd/madvoc/result/JsonResult.java
+++ b/jodd-madvoc/src/main/java/jodd/madvoc/result/JsonResult.java
@@ -55,7 +55,7 @@ public class JsonResult {
 	 * Creates JSON result from given object. The object will be serialized to JSON.
 	 */
 	public static JsonResult of(final Object object) {
-		final String json = JsonSerializer.create().deep(true).serialize(object);
+		final String json = JsonSerializer.createJsonParser().deep(true).serialize(object);
 		return new JsonResult(json);
 	}
 
@@ -86,7 +86,7 @@ public class JsonResult {
 
 		errorMap.put("details", details);
 
-		final String json = JsonSerializer.create().deep(true).serialize(errorMap);
+		final String json = JsonSerializer.createJsonParser().deep(true).serialize(errorMap);
 		return new JsonResult(json).status(HttpStatus.error500().internalError());
 	}
 

--- a/jodd-madvoc/src/main/java/jodd/madvoc/scope/JsonBodyScope.java
+++ b/jodd-madvoc/src/main/java/jodd/madvoc/scope/JsonBodyScope.java
@@ -77,7 +77,7 @@ public class JsonBodyScope implements MadvocScope {
 	 * Parses request body into the target type.
 	 */
 	protected Object parseRequestBody(final String body, final Class targetType) {
-		return JsonParser.create().parse(body, targetType);
+		return JsonParser.createJsonParser().parse(body, targetType);
 	}
 
 }

--- a/jodd-madvoc/src/testInt/java/jodd/madvoc/TagActionTestBase.java
+++ b/jodd-madvoc/src/testInt/java/jodd/madvoc/TagActionTestBase.java
@@ -80,7 +80,7 @@ public abstract class TagActionTestBase {
 
 		assertEquals(500, response.statusCode());
 		String body = response.bodyText();
-		Map map = JsonParser.create().parse(body);
+		Map map = JsonParser.createJsonParser().parse(body);
 
 		assertEquals("/ by zero", map.get("message"));
 		assertEquals("java.lang.ArithmeticException", map.get("error"));


### PR DESCRIPTION
The class JsonParser is used to represent  a json Parser.  This method named 'create' is to create a Json parser. Thus, the method name 'createJsonParser' is more intuitive than 'create'.

The class Socks5ProxySocketFactory is used to represent  Socks5ProxySocketFactory.  This method named 'fill' is to read a sequence of bytes. Thus, the method name 'readBytes' is more intuitive than 'fill'.