### PR TITLE
Optimize empty String tests on Java 9+

### DIFF
--- a/jodd-bean/src/main/java/jodd/bean/BeanUtilBean.java
+++ b/jodd-bean/src/main/java/jodd/bean/BeanUtilBean.java
@@ -139,7 +139,7 @@ public class BeanUtilBean extends BeanUtilUtil implements BeanUtil {
 
 	protected Object getSimpleProperty(final BeanProperty bp) {
 
-		if (bp.name.length() == 0) {
+		if (bp.name.isEmpty()) {
 			if (bp.indexString != null) {
 				// index string exist, but property name is missing
 				return bp.bean;

--- a/jodd-bean/src/main/java/jodd/typeconverter/impl/ClassArrayConverter.java
+++ b/jodd-bean/src/main/java/jodd/typeconverter/impl/ClassArrayConverter.java
@@ -68,7 +68,7 @@ public class ClassArrayConverter extends ArrayConverter<Class> {
 		for (int i = 0; i < strings.length; i++) {
 			strings[count] = strings[i].trim();
 
-			if (strings[count].length() == 0) {
+			if (strings[count].isEmpty()) {
 				continue;
 			}
 

--- a/jodd-core/src/main/java/jodd/io/ZipUtil.java
+++ b/jodd-core/src/main/java/jodd/io/ZipUtil.java
@@ -286,7 +286,7 @@ public class ZipUtil {
 			path = file.getName();
 		}
 
-		while (path.length() != 0 && path.charAt(0) == '/') {
+		while (!path.isEmpty() && path.charAt(0) == '/') {
 			path = path.substring(1);
 		}
 
@@ -345,7 +345,7 @@ public class ZipUtil {
 	 * Adds byte content into the zip as a file.
 	 */
 	public static void addToZip(final ZipOutputStream zos, final byte[] content, String path, final String comment) throws IOException {
-		while (path.length() != 0 && path.charAt(0) == '/') {
+		while (!path.isEmpty() && path.charAt(0) == '/') {
 			path = path.substring(1);
 		}
 
@@ -373,7 +373,7 @@ public class ZipUtil {
 	}
 
 	public static void addFolderToZip(final ZipOutputStream zos, String path, final String comment) throws IOException {
-		while (path.length() != 0 && path.charAt(0) == '/') {
+		while (!path.isEmpty() && path.charAt(0) == '/') {
 			path = path.substring(1);
 		}
 

--- a/jodd-core/src/main/java/jodd/io/upload/FileUploadHeader.java
+++ b/jodd-core/src/main/java/jodd/io/upload/FileUploadHeader.java
@@ -56,7 +56,7 @@ public class FileUploadHeader {
 			if (formFileName == null) {
 				return;
 			}
-			if (formFileName.length() == 0) {
+			if (formFileName.isEmpty()) {
 				path = StringPool.EMPTY;
 				fileName = StringPool.EMPTY;
 			}
@@ -68,7 +68,7 @@ public class FileUploadHeader {
 				path = formFileName.substring(0, ls);
 				fileName = formFileName.substring(ls + 1);
 			}
-			if (fileName.length() > 0) {
+			if (!fileName.isEmpty()) {
 				this.contentType = getContentType(dataHeader);
 				mimeType = getMimeType(contentType);
 				mimeSubtype = getMimeSubtype(contentType);

--- a/jodd-core/src/main/java/jodd/io/upload/MultipartStreamParser.java
+++ b/jodd-core/src/main/java/jodd/io/upload/MultipartStreamParser.java
@@ -130,14 +130,14 @@ public class MultipartStreamParser {
 
 			if (header.isFile) {
 				String fileName = header.fileName;
-				if (fileName.length() > 0) {
+				if (!fileName.isEmpty()) {
 					if (header.contentType.indexOf("application/x-macbinary") > 0) {
 						input.skipBytes(128);
 					}
 				}
 				FileUpload newFile = fileUploadFactory.create(input);
 				newFile.processStream();
-				if (fileName.length() == 0) {
+				if (fileName.isEmpty()) {
 					// file was specified, but no name was provided, therefore it was not uploaded
 					if (newFile.getSize() == 0) {
 						newFile.size = -1;

--- a/jodd-core/src/main/java/jodd/net/URLCoder.java
+++ b/jodd-core/src/main/java/jodd/net/URLCoder.java
@@ -493,7 +493,7 @@ public class URLCoder {
 
 			url.append(encodeQueryParam(name, encoding));
 
-			if ((value != null) && (value.length() > 0)) {
+			if (value != null && !value.isEmpty()) {
 				url.append('=');
 				url.append(encodeQueryParam(value, encoding));
 			}

--- a/jodd-core/src/main/java/jodd/util/ResourceBundleMessageResolver.java
+++ b/jodd-core/src/main/java/jodd/util/ResourceBundleMessageResolver.java
@@ -106,7 +106,7 @@ public class ResourceBundleMessageResolver {
 				return msg;
 			}
 
-			if (bundleName == null || bundleName.length() == 0) {
+			if (bundleName == null || bundleName.isEmpty()) {
 				break;
 			}
 			int ndx = bundleName.lastIndexOf('.');

--- a/jodd-core/src/main/java/jodd/util/StringUtil.java
+++ b/jodd-core/src/main/java/jodd/util/StringUtil.java
@@ -298,12 +298,19 @@ public class StringUtil {
 	 * Determines if a string is empty (<code>null</code> or zero-length).
 	 */
 	public static boolean isEmpty(final CharSequence string) {
-		return ((string == null) || (string.length() == 0));
+		return (string == null || string.length() == 0);
+	}
+
+	/**
+	 * Determines if a string is empty (<code>null</code> or zero-length).
+	 */
+	public static boolean isEmpty(final String string) {
+		return (string == null || string.isEmpty());
 	}
 
 	/**
 	 * Determines if string array contains empty strings.
-	 * @see #isEmpty(CharSequence)
+	 * @see #isEmpty(String)
 	 */
 	public static boolean isAllEmpty(final String... strings) {
 		for (final String string : strings) {
@@ -530,7 +537,7 @@ public class StringUtil {
 	 * @return The decapitalized version of the string.
 	 */
 	public static String decapitalize(final String name) {
-		if (name.length() == 0) {
+		if (name.isEmpty()) {
 			return name;
 		}
 		if (name.length() > 1 &&
@@ -706,7 +713,7 @@ public class StringUtil {
 	 * @return array of tokens
 	 */
 	public static String[] splitc(final String src, final String d) {
-		if ((d.length() == 0) || (src.length() == 0)) {
+		if (d.isEmpty() || src.isEmpty()) {
 			return new String[] {src};
 		}
 		return splitc(src, d.toCharArray());
@@ -722,7 +729,7 @@ public class StringUtil {
 	 * @return array of tokens
 	 */
 	public static String[] splitc(final String src, final char[] delimiters) {
-		if ((delimiters.length == 0) || (src.length() == 0) ) {
+		if (delimiters.length == 0 || src.isEmpty()) {
 			return new String[] {src};
 		}
 		final char[] srcc = src.toCharArray();
@@ -780,7 +787,7 @@ public class StringUtil {
 	 * @return array of tokens
 	 */
 	public static String[] splitc(final String src, final char delimiter) {
-		if (src.length() == 0) {
+		if (src.isEmpty()) {
 			return new String[] {EMPTY};
 		}
 		final char[] srcc = src.toCharArray();
@@ -1320,20 +1327,14 @@ public class StringUtil {
 	 * Returns if string starts with given character.
 	 */
 	public static boolean startsWithChar(final String s, final char c) {
-		if (s.length() == 0) {
-			return false;
-		}
-		return s.charAt(0) == c;
+		return !s.isEmpty() && s.charAt(0) == c;
 	}
 
 	/**
 	 * Returns if string ends with provided character.
 	 */
 	public static boolean endsWithChar(final String s, final char c) {
-		if (s.length() == 0) {
-			return false;
-		}
-		return s.charAt(s.length() - 1) == c;
+		return !s.isEmpty() && s.charAt(s.length() - 1) == c;
 	}
 
 
@@ -1867,7 +1868,7 @@ public class StringUtil {
 	 * Strips leading char if string starts with one.
 	 */
 	public static String stripLeadingChar(final String string, final char c) {
-		if (string.length() > 0) {
+		if (!string.isEmpty()) {
 			if (string.charAt(0) == c) {
 				return string.substring(1);
 			}
@@ -1879,7 +1880,7 @@ public class StringUtil {
 	 * Strips trailing char if string ends with one.
 	 */
 	public static String stripTrailingChar(final String string, final char c) {
-		if (string.length() > 0) {
+		if (!string.isEmpty()) {
 			if (string.charAt(string.length() - 1) == c) {
 				return string.substring(0, string.length() - 1);
 			}
@@ -1891,7 +1892,7 @@ public class StringUtil {
 	 * Strips leading and trailing char from given string.
 	 */
 	public static String stripChar(final String string, final char c) {
-		if (string.length() == 0) {
+		if (string.isEmpty()) {
 			return string;
 		}
 		if (string.length() == 1) {
@@ -1973,20 +1974,14 @@ public class StringUtil {
 	 */
 	public static String trimDown(String string) {
 		string = string.trim();
-		if (string.length() == 0) {
-			string = null;
-		}
-		return string;
+		return string.isEmpty() ? null : string;
 	}
 
 	/**
 	 * Crops string by setting empty strings to <code>null</code>.
 	 */
 	public static String crop(final String string) {
-		if (string.length() == 0) {
-			return null;
-		}
-		return string;
+		return string.isEmpty() ? null : string;
 	}
 
 	/**

--- a/jodd-db/src/main/java/jodd/db/oom/DbMetaUtil.java
+++ b/jodd-db/src/main/java/jodd/db/oom/DbMetaUtil.java
@@ -52,7 +52,7 @@ public class DbMetaUtil {
 		if (dbTable != null) {
 			tableName = dbTable.value().trim();
 		}
-		if ((tableName == null) || (tableName.length() == 0)) {
+		if (tableName == null || tableName.isEmpty()) {
 			tableName = tableNamingStrategy.convertEntityNameToTableName(type);
 		} else {
 			if (!tableNamingStrategy.isStrictAnnotationNames()) {
@@ -72,7 +72,7 @@ public class DbMetaUtil {
 		if (dbTable != null) {
 			schemaName = dbTable.schema().trim();
 		}
-		if ((schemaName == null) || (schemaName.length() == 0)) {
+		if (schemaName == null || schemaName.isEmpty()) {
 			schemaName = defaultSchemaName;
 		}
 		return schemaName;

--- a/jodd-db/src/main/java/jodd/db/oom/mapper/DefaultResultSetMapper.java
+++ b/jodd-db/src/main/java/jodd/db/oom/mapper/DefaultResultSetMapper.java
@@ -169,14 +169,14 @@ public class DefaultResultSetMapper extends BaseResultSetMapper {
 						} catch (SQLException sex) {
 							// ignore
 					}
-						if ((tableName != null) && (tableName.length() == 0)) {
+						if (tableName != null && tableName.isEmpty()) {
 							tableName = null;
 						}
 					}
 				}
 
 				columnName = columnName.trim();
-				if (columnName.length() == 0) {
+				if (columnName.isEmpty()) {
 					columnName = null;
 				}
 

--- a/jodd-db/src/main/java/jodd/db/oom/sqlgen/chunks/ColumnsSelectChunk.java
+++ b/jodd-db/src/main/java/jodd/db/oom/sqlgen/chunks/ColumnsSelectChunk.java
@@ -155,7 +155,7 @@ public class ColumnsSelectChunk extends SqlChunk {
 				this.columnRefArr = null;
 				this.includeColumns = COLS_ALL_BUT_ID;
 			} else if (
-					reference.length() != 0
+					!reference.isEmpty()
 					&& reference.charAt(0) == '['
 					&& reference.charAt(reference.length() - 1) == ']') {
 
@@ -197,7 +197,7 @@ public class ColumnsSelectChunk extends SqlChunk {
 		separateByCommaOrSpace(out);
 
 		// special case, only column name, no table ref/name
-		if (tableRef.length() == 0) {
+		if (tableRef.isEmpty()) {
 			out.append(columnRef);
 			return;
 		}

--- a/jodd-db/src/main/java/jodd/db/oom/sqlgen/chunks/ReferenceChunk.java
+++ b/jodd-db/src/main/java/jodd/db/oom/sqlgen/chunks/ReferenceChunk.java
@@ -66,13 +66,13 @@ public class ReferenceChunk extends SqlChunk {
 			this.onlyId = false;
 		} else {
 			String ref = reference.substring(0, dotNdx);
-			if (ref.length() == 0) {
+			if (ref.isEmpty()) {
 				ref = null;
 			}
 			this.tableRef = ref;
 
 			ref = reference.substring(dotNdx + 1);
-			if (ref.length() == 0) {
+			if (ref.isEmpty()) {
 				ref = null;
 			}
 			this.columnRef = ref;

--- a/jodd-db/src/main/java/jodd/db/oom/sqlgen/chunks/TableChunk.java
+++ b/jodd-db/src/main/java/jodd/db/oom/sqlgen/chunks/TableChunk.java
@@ -88,7 +88,7 @@ public class TableChunk extends SqlChunk {
 		if (spaceNdx != -1) {
 			this.entityName = tableRef.substring(0, spaceNdx);
 			String alias = tableRef.substring(spaceNdx + 1).trim();
-			tableAlias = alias.length() == 0 ? null : alias;
+			tableAlias = alias.isEmpty() ? null : alias;
 		} else {
 			this.entityName = tableRef;
 			this.tableAlias = null;

--- a/jodd-http/src/test/java/jodd/http/NanoHTTPD.java
+++ b/jodd-http/src/test/java/jodd/http/NanoHTTPD.java
@@ -539,7 +539,7 @@ public class NanoHTTPD
 				if ( st.hasMoreTokens())
 				{
 					String line = in.readLine();
-					while ( line != null && line.trim().length() > 0 )
+					while (line != null && !line.trim().isEmpty())
 					{
 						int p = line.indexOf( ':' );
 						if ( p >= 0 )
@@ -575,7 +575,7 @@ public class NanoHTTPD
 					boundarycount++;
 					Properties item = new Properties();
 					mpline = in.readLine();
-					while (mpline != null && mpline.trim().length() > 0)
+					while (mpline != null && !mpline.trim().isEmpty())
 					{
 						int p = mpline.indexOf( ':' );
 						if (p != -1)

--- a/jodd-madvoc/src/main/java/jodd/madvoc/component/ResultMapper.java
+++ b/jodd-madvoc/src/main/java/jodd/madvoc/component/ResultMapper.java
@@ -169,7 +169,7 @@ public class ResultMapper extends ResultMapperCfg {
 							path += '.' + value.substring(0, dotNdx);
 							value = value.substring(dotNdx + 2);
 						} else {
-							if (value.length() > 0) {
+							if (!value.isEmpty()) {
 								if (StringUtil.endsWithChar(path, '/')) {
 									path += value;
 								} else {

--- a/jodd-madvoc/src/main/java/jodd/madvoc/component/RootPackages.java
+++ b/jodd-madvoc/src/main/java/jodd/madvoc/component/RootPackages.java
@@ -70,7 +70,7 @@ public class RootPackages {
 		}
 
 		// fix mapping
-		if (mapping.length() > 0) {
+		if (!mapping.isEmpty()) {
 			// mapping must start with the slash
 			if (!mapping.startsWith(StringPool.SLASH)) {
 				mapping = StringPool.SLASH + mapping;

--- a/jodd-madvoc/src/main/java/jodd/madvoc/macro/BasePathMacros.java
+++ b/jodd-madvoc/src/main/java/jodd/madvoc/macro/BasePathMacros.java
@@ -190,7 +190,7 @@ public abstract class BasePathMacros implements PathMacros {
 					break;
 				}
 				nextFixed = fixed[nexti];
-				if (nextFixed.length() != 0) {
+				if (!nextFixed.isEmpty()) {
 					break;
 				}
 				// next fixed is an empty string, so skip the next macro.

--- a/jodd-petite/src/main/java/jodd/petite/AnnotationResolver.java
+++ b/jodd-petite/src/main/java/jodd/petite/AnnotationResolver.java
@@ -58,7 +58,7 @@ public class AnnotationResolver {
 		if (petiteBean != null) {
 			name = petiteBean.value().trim();
 		}
-		if ((name == null) || (name.length() == 0)) {
+		if (name == null || name.isEmpty()) {
 			if (useLongTypeName) {
 				name = type.getName();
 			} else {

--- a/jodd-petite/src/main/java/jodd/petite/resolver/ReferencesResolver.java
+++ b/jodd-petite/src/main/java/jodd/petite/resolver/ReferencesResolver.java
@@ -114,7 +114,7 @@ public class ReferencesResolver {
 		BeanReferences reference = null;
 
 		String name = ref.value().trim();
-		if (name.length() != 0) {
+		if (!name.isEmpty()) {
 			reference = BeanReferences.of(name);
 		}
 
@@ -135,7 +135,7 @@ public class ReferencesResolver {
 		BeanReferences reference = null;
 
 		String name = ref.value().trim();
-		if (name.length() != 0) {
+		if (!name.isEmpty()) {
 			reference = BeanReferences.of(name);
 		}
 
@@ -358,7 +358,7 @@ public class ReferencesResolver {
 		}
 
 		value = value.trim();
-		if (value.length() == 0) {
+		if (value.isEmpty()) {
 			return null;
 		}
 

--- a/jodd-props/src/main/java/jodd/props/PropsData.java
+++ b/jodd-props/src/main/java/jodd/props/PropsData.java
@@ -269,7 +269,7 @@ public class PropsData implements Cloneable {
 			}
 
 			if (skipEmptyProps) {
-				if (newValue.length() == 0) {
+				if (newValue.isEmpty()) {
 					return null;
 				}
 			}

--- a/jodd-props/src/main/java/jodd/props/PropsParser.java
+++ b/jodd-props/src/main/java/jodd/props/PropsParser.java
@@ -225,7 +225,7 @@ public class PropsParser implements Cloneable {
 							currentSection = sb.toString().trim();
 							sb.setLength(0);
 							insideSection = false;
-							if (currentSection.length() == 0) {
+							if (currentSection.isEmpty()) {
 								currentSection = null;
 							}
 						} else {
@@ -370,7 +370,7 @@ public class PropsParser implements Cloneable {
 		String fullKey = key;
 
 		if (section != null) {
-			if (fullKey.length() != 0) {
+			if (!fullKey.isEmpty()) {
 				fullKey = section + '.' + fullKey;
 			} else {
 				fullKey = section;
@@ -388,7 +388,7 @@ public class PropsParser implements Cloneable {
 			}
 		}
 
-		if (v.length() == 0 && skipEmptyProps) {
+		if (v.isEmpty() && skipEmptyProps) {
 			return;
 		}
 

--- a/jodd-proxetta/src/main/java/jodd/asm7/TypePath.java
+++ b/jodd-proxetta/src/main/java/jodd/asm7/TypePath.java
@@ -117,7 +117,7 @@ public final class TypePath {
    * @return the corresponding TypePath object, or {@literal null} if the path is empty.
    */
   public static TypePath fromString(final String typePath) {
-    if (typePath == null || typePath.length() == 0) {
+    if (typePath == null || typePath.isEmpty()) {
       return null;
     }
     int typePathLength = typePath.length();

--- a/jodd-proxetta/src/main/java/jodd/pathref/Pathref.java
+++ b/jodd-proxetta/src/main/java/jodd/pathref/Pathref.java
@@ -101,7 +101,7 @@ public class Pathref<C> {
 	 * Appends method name to existing path.
 	 */
 	protected void append(final String methodName) {
-		if (path.length() != 0) {
+		if (!path.isEmpty()) {
 			path += StringPool.DOT;
 		}
 		if (methodName.startsWith(StringPool.LEFT_SQ_BRACKET)) {

--- a/jodd-proxetta/src/main/java/jodd/proxetta/InvokeInfo.java
+++ b/jodd-proxetta/src/main/java/jodd/proxetta/InvokeInfo.java
@@ -58,7 +58,7 @@ public class InvokeInfo {
 		// arguments
 		List<String> args = new ArrayList<>();
 		MutableInteger from = new MutableInteger(1);
-		if (description.length() != 0) {
+		if (!description.isEmpty()) {
 			while (description.charAt(from.value) != ')') {
 				String a = AsmUtil.typedescToSignature(description, from);
 				args.add(a);
@@ -69,7 +69,7 @@ public class InvokeInfo {
 		args.toArray(arguments);
 
 		from.value++;
-		returnType = description.length() > 0 ?
+		returnType = !description.isEmpty() ?
 				AsmUtil.typedescToSignature(description, from) :
 				className;
 

--- a/jodd-proxetta/src/main/java/jodd/proxetta/asm/ProxettaAsmUtil.java
+++ b/jodd-proxetta/src/main/java/jodd/proxetta/asm/ProxettaAsmUtil.java
@@ -599,7 +599,7 @@ public class ProxettaAsmUtil {
 				break;
 			default:
 				String rtname = methodInfo.getReturnType().getRawName();
-				returnType = rtname.length() == 0 ?
+				returnType = rtname.isEmpty() ?
 					AsmUtil.typeToSignature(methodInfo.getReturnType().getType()) :
 					AsmUtil.typedesc2ClassName(rtname);
 				break;

--- a/jodd-servlet/src/main/java/jodd/servlet/DispatcherUtil.java
+++ b/jodd-servlet/src/main/java/jodd/servlet/DispatcherUtil.java
@@ -182,7 +182,7 @@ public class DispatcherUtil {
 	public static String getFullUrl(final HttpServletRequest request) {
 		String url = request.getRequestURI();
 		String query = request.getQueryString();
-		if ((query != null) && (query.length() != 0)) {
+		if (query != null && !query.isEmpty()) {
 			url += '?' + query;
 		}
 		return url;
@@ -194,7 +194,7 @@ public class DispatcherUtil {
 	public static String getUrl(final HttpServletRequest request) {
 		String servletPath = request.getServletPath();
 		String query = request.getQueryString();
-		if ((query != null) && (query.length() != 0)) {
+		if (query != null && !query.isEmpty()) {
 			servletPath += '?' + query;
 		}
 		return servletPath;

--- a/jodd-servlet/src/main/java/jodd/servlet/ServletUtil.java
+++ b/jodd-servlet/src/main/java/jodd/servlet/ServletUtil.java
@@ -615,7 +615,7 @@ public class ServletUtil {
 					emptyCount++;
 					continue;
 				}
-				if (paramValue.length() == 0) {
+				if (paramValue.isEmpty()) {
 					emptyCount++;
 					if (treatEmptyParamsAsNull) {
 						paramValue = null;

--- a/jodd-servlet/src/main/java/jodd/servlet/filter/GzipFilter.java
+++ b/jodd-servlet/src/main/java/jodd/servlet/filter/GzipFilter.java
@@ -192,7 +192,7 @@ public class GzipFilter implements Filter {
 	protected boolean isGzipEligible(final HttpServletRequest request) {
 		// request parameter name
 
-		if (requestParameterName.length() != 0) {
+		if (!requestParameterName.isEmpty()) {
 			String forceGzipString = request.getParameter(requestParameterName);
 
 			if (forceGzipString != null) {
@@ -221,7 +221,7 @@ public class GzipFilter implements Filter {
 			// extension
 			String extension = FileNameUtil.getExtension(uri);
 
-			if (extension.length() > 0) {
+			if (!extension.isEmpty()) {
 				extension = extension.toLowerCase();
 
 				if (StringUtil.equalsOne(extension, extensions) != -1) {

--- a/jodd-servlet/src/main/java/jodd/servlet/lagarto/LagartoServletFilter.java
+++ b/jodd-servlet/src/main/java/jodd/servlet/lagarto/LagartoServletFilter.java
@@ -114,7 +114,7 @@ public abstract class LagartoServletFilter implements Filter {
 	 */
 	protected boolean acceptActionPath(final HttpServletRequest request, final String actionPath) {
 		final String extension = FileNameUtil.getExtension(actionPath);
-		if (extension.length() == 0) {
+		if (extension.isEmpty()) {
 			return true;
 		}
 		if (extension.equals("html") || extension.equals("htm")) {


### PR DESCRIPTION
Motivation:

Don't use String#length() to test emptyness. This computes the actual length, which might be non trivial with Java 9 where the underlying encoding is UTF-8 and not US-ASCII.
Use String#isEmpty() instead as it just has to check the length of the nuderlying byte array.

Modifications:

* string.length() == 0 => string.isEmpty()
* string.length() != 0 => !string.isEmpty()
* string.length() > 0 => !string.isEmpty()
* overload StringUtil#isEmpty to accept a String where implementation can be optimized. Original method doesn't seem to be used but it's public so I didn't remove it.

Result:

More performant String emptiness test