### PR TITLE
Introduce StringBuilderPool

### DIFF
--- a/jodd-core/src/main/java/jodd/net/HtmlEncoder.java
+++ b/jodd-core/src/main/java/jodd/net/HtmlEncoder.java
@@ -25,6 +25,7 @@
 
 package jodd.net;
 
+import jodd.util.StringBuilderPool;
 import jodd.util.StringPool;
 
 /**
@@ -140,19 +141,17 @@ public class HtmlEncoder {
 			return StringPool.EMPTY;
 		}
 
-		StringBuilder buffer = new StringBuilder(len + (len >> 2));
-
-		for (int i = 0; i < len; i++) {
-			char c = text.charAt(i);
-
-			if (c < bufflen) {
-				buffer.append(buff[c]);
-			} else {
-				buffer.append(c);
+		return StringBuilderPool.DEFAULT.withPooledBuffer(sb -> {
+				for (int i = 0; i < len; i++) {
+					char c = text.charAt(i);
+					if (c < bufflen) {
+						sb.append(buff[c]);
+					} else {
+						sb.append(c);
+					}
+				}
+				return sb.toString();
 			}
-		}
-		return buffer.toString();
+		);
 	}
-
-
 }

--- a/jodd-core/src/main/java/jodd/util/StringBuilderPool.java
+++ b/jodd-core/src/main/java/jodd/util/StringBuilderPool.java
@@ -1,0 +1,59 @@
+// Copyright (c) 2020-present, Jodd Team (http://jodd.org)
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice,
+// this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+package jodd.util;
+
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.function.Function;
+
+public class StringBuilderPool {
+
+	public static StringBuilderPool DEFAULT = new StringBuilderPool(10_000);
+
+	private final ConcurrentLinkedQueue<StringBuilder> pool = new ConcurrentLinkedQueue<>();
+	private final int maxPooledLength;
+
+	public StringBuilderPool(int maxPooledLength) {
+		this.maxPooledLength = maxPooledLength;
+	}
+
+	private StringBuilder poll() {
+		StringBuilder sb = pool.poll();
+		return sb != null ? sb : new StringBuilder();
+	}
+
+	private void offer(StringBuilder sb) {
+		if (sb.length() <= maxPooledLength) {
+			pool.offer(sb);
+		}
+	}
+
+	public <T> T withPooledBuffer(Function<StringBuilder, T> f) {
+		StringBuilder sb = poll();
+		T res = f.apply(sb);
+		offer(sb);
+		return res;
+	}
+}

--- a/jodd-core/src/main/java/jodd/util/StringUtil.java
+++ b/jodd-core/src/main/java/jodd/util/StringUtil.java
@@ -257,26 +257,21 @@ public class StringUtil {
 	 * @param ch  character to remove
 	 */
 	public static String remove(final String string, final char ch) {
+		if (isEmpty(string)) {
+			return string;
+		}
+
 		final int stringLen = string.length();
-		final char[] result = new char[stringLen];
-		int offset = 0;
 
-		for (int i = 0; i < stringLen; i++) {
-			final char c = string.charAt(i);
-
-			if (c == ch) {
-				continue;
+		return StringBuilderPool.DEFAULT.withPooledBuffer(sb -> {
+			for (int i = 0; i < stringLen; i++) {
+				char c = string.charAt(i);
+				if (c != ch) {
+					sb.append(c);
+				}
 			}
-
-			result[offset] = c;
-			offset++;
-		}
-
-		if (offset == stringLen) {
-			return string;	// no changes
-		}
-
-		return new String(result, 0, offset);
+			return sb.length() == stringLen ? string : sb.toString();
+		});
 	}
 
 	// ---------------------------------------------------------------- miscellaneous


### PR DESCRIPTION
Motivation:

A lot of StringBuilders are allocated on the hotpath, in particular in utils used Lagarto.

Modifications:

* StringBuilderPool uses a ConcurrentLinkedQueue pool instead of a ThreadLocal so that containers don't complain about leaks on classloader reboot. Also, this strategy supports re-entrant calls.
* Offered StringBuilders length is capped to avoid large resident memory usage.
* Usage is a borrow pattern where user has to pass a Function<StringBuilder, T>.

Result:

Util to pool StringBuilder instances