### PR TITLE
Add test for Option.toString

### DIFF
--- a/jodd-core/src/test/java/jodd/cli/CliOptionsTest.java
+++ b/jodd-core/src/test/java/jodd/cli/CliOptionsTest.java
@@ -25,6 +25,7 @@
 
 package jodd.cli;
 
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
@@ -131,5 +132,19 @@ class CliOptionsTest {
 		cli.accept("-a=1", "--foo=F");
 		assertEquals("[1, F]", out.toString());
 		out.clear();
+	}
+
+	@Test
+	void testToString() throws Exception {
+		final List<String> out = new ArrayList<>();
+		final Cli cli = new Cli();
+		cli.option().shortName("a").hasArg().with(out::add);
+		cli.option().longName("foo").hasArg().with(out::add);
+		cli.printUsage("cmd");
+		cli.accept("-a", "1", "--foo", "F");
+		out.clear();
+		cli.accept("-a=1", "--foo=F");
+		out.clear();
+		Assertions.assertEquals("--foo", cli.option().longName("foo").hasArg().with(out::add).toString());
 	}
 }


### PR DESCRIPTION
<!--
You Are Awesome! Thank you for your contribution!
-->

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/oblac/jodd/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## Current behavior

No test for `Option.toString`

## New behavior?

Hey 😊
I want to contribute the following test:

Test that `cli.option().longName("foo").hasArg().with(out::add).toString()` is equal to `"--foo"`.
This tests the method [`Option.toString`](https://github.com/oblac/jodd/blob/f039c7152445cd80f2234ce92cd7e97985ea3311/jodd-core/src/main/java/jodd/cli/Option.java#L83).
This test is based on the test [`testOptionWithValue`](https://github.com/oblac/jodd/blob/f039c7152445cd80f2234ce92cd7e97985ea3311/jodd-core/src/test/java/jodd/cli/CliOptionsTest.java#L111).

Curious to hear what you think!

Also, is the description I provided of the test helping you to answer to this pull request? Why (not)?

(I wrote this test as part of a research study at TU Delft. [Find out more](https://github.com/lacinoire/lacinoire/blob/main/README.md))